### PR TITLE
build: configurable paths for azure-nvme-id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,17 @@ enable_testing()
 add_compile_options(-Wextra -Wall -Werror -std=gnu11 -D_GNU_SOURCE=1)
 add_executable(azure-nvme-id src/main.c)
 
-install(TARGETS azure-nvme-id DESTINATION bin)
-install(FILES udev/80-azure-nvme.rules DESTINATION /lib/udev/rules.d)
+set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
+set(UDEV_RULES_INSTALL_DIR "/lib/udev/rules.d")
+
+configure_file(
+  "${PROJECT_SOURCE_DIR}/udev/80-azure-nvme.rules.in"
+  "${PROJECT_BINARY_DIR}/udev/80-azure-nvme.rules"
+  @ONLY
+)
+
+install(TARGETS azure-nvme-id DESTINATION ${AZURE_NVME_ID_INSTALL_DIR})
+install(FILES udev/80-azure-nvme.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/udev/80-azure-nvme.rules.in
+++ b/udev/80-azure-nvme.rules.in
@@ -21,7 +21,7 @@ LABEL="azure_nvme_remote_start"
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_start"
-ATTR{nsid}=="?*", IMPORT{program}="/usr/local/bin/azure-nvme-id --udev"
+ATTR{nsid}=="?*", IMPORT{program}="@AZURE_NVME_ID_INSTALL_DIR@/azure-nvme-id --udev"
 ENV{AZURE_NVME_TYPE}=="os", SYMLINK+="disk/azure/os"
 ENV{AZURE_NVME_TYPE}=="?*", ENV{AZURE_NVME_INDEX}=="?*", SYMLINK+="disk/azure/$env{AZURE_NVME_TYPE}/by-index/$env{AZURE_NVME_INDEX}"
 ENV{AZURE_NVME_TYPE}=="?*", ENV{AZURE_NVME_LUN}=="?*", SYMLINK+="disk/azure/$env{AZURE_NVME_TYPE}/by-lun/$env{AZURE_NVME_LUN}"


### PR DESCRIPTION
To make it a bit more packaging-friendly:

- make rules rules a .in template which gets updated at build time with the correct path for azure-nvme-id

- move default path to /usr/sbin/azure-nvme-id as it requires root