### PR TITLE
feat(udev): enable NSID->LUN mappings by configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ add_executable(azure-nvme-id src/main.c)
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
 set(UDEV_RULES_INSTALL_DIR "/lib/udev/rules.d")
 
+option(AZURE_LUN_CALCULATION_BY_NSID_ENABLED "Enable fallback \"LUN\" calculation via NSID" ON)
+if(AZURE_LUN_CALCULATION_BY_NSID_ENABLED)
+    set(AZURE_LUN_CALCULATION_BY_NSID_ENABLED 1)
+else()
+    set(AZURE_LUN_CALCULATION_BY_NSID_ENABLED 0)
+endif()
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/udev/80-azure-nvme.rules.in"
   "${PROJECT_BINARY_DIR}/udev/80-azure-nvme.rules"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ To run in udev mode:
 DEVNAME=/dev/nvme0n1 azure-nvme-id --udev
 ```
 
+### Enabling LUN Calculation by Namespace Identifier (Default)
+
+The "LUN" configured by the user for data disks can be computed by the namespace identifier for "MSFT NVMe Accelerator v1.0" controllers.
+
+This is currently enabled by default to support cases where there is no identification information available in the vendor-specific field of Identify Namespace data structure.
+
+It can be explicitly enabled by passing AZURE_LUN_CALCULATION_BY_NSID_ENABLED=1 to cmake:
+
+```
+cmake -DAZURE_LUN_CALCULATION_BY_NSID_ENABLED=1 .
+```
+
+## Disabling LUN Calculation by Namespace Identifier
+
+Pass AZURE_LUN_CALCULATION_BY_NSID_ENABLED=0 to cmake:
+
+```
+cmake -DAZURE_LUN_CALCULATION_BY_NSID_ENABLED=0 .
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/udev/80-azure-nvme.rules.in
+++ b/udev/80-azure-nvme.rules.in
@@ -14,10 +14,10 @@ ATTR{nsid}=="?*", ENV{AZURE_NVME_TYPE}="local"
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_remote_start"
-# !! USE AT YOUR OWN RISK: To use OS/data lun mappings based on nsid for Linux VMs, uncomment the following lines:
-#ATTR{nsid}=="1", ENV{AZURE_NVME_TYPE}="os", GOTO="azure_nvme_start"
-#ATTR{nsid}=="?*", ENV{AZURE_NVME_TYPE}="data"
-#ENV{AZURE_NVME_TYPE}=="data", ATTR{nsid}=="?*", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_NVME_LUN}="$result"
+ATTR{nsid}=="?*", ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}="@AZURE_LUN_CALCULATION_BY_NSID_ENABLED@"
+ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ATTR{nsid}=="1", ENV{AZURE_NVME_TYPE}="os", GOTO="azure_nvme_start"
+ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ATTR{nsid}=="?*", ENV{AZURE_NVME_TYPE}="data"
+ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ENV{AZURE_NVME_TYPE}=="data", ATTR{nsid}=="?*", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_NVME_LUN}="$result"
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_start"


### PR DESCRIPTION
NVMe disks provided by MSFT NVMe Accelerator v1.0 configures the NSIDs as:
    - OS disk NSID = 1
    - Data disk NSID on Linux = user-configured LUN + 2
    
Allow it to be enabled at build-time with:
```
cmake -DAZURE_LUN_CALCULATION_BY_NSID_ENABLED=1 .
```
    
If we can determine it is safe in all scenarios, we'll set it to the default.