### PR TITLE
Fix build without pandoc

### DIFF
--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -1,22 +1,22 @@
 find_program(PANDOC_EXECUTABLE pandoc)
+if(NOT PANDOC_EXECUTABLE)
+        message(WARNING "Pandoc not found, will not generate manpages")
+        return()
+endif()
 
 string(TIMESTAMP TODAY "%B %d, %Y")
 
-if(PANDOC_EXECUTABLE)
-        add_custom_command(
-                OUTPUT ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
-                COMMAND ${PANDOC_EXECUTABLE}
-                        ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
-                        --standalone --from markdown --to man
-                        --variable footer="azure-nvme-id ${VERSION}"
-                        --variable date="${TODAY}"
-                        -o ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
-                DEPENDS ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
-                COMMENT "Generating manpage for azure-nvme-id"
-        )
-else()
-        message(WARNING "Pandoc not found, will not generate manpages")
-endif()
+add_custom_command(
+	OUTPUT ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
+	COMMAND ${PANDOC_EXECUTABLE}
+		${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
+		--standalone --from markdown --to man
+		--variable footer="azure-nvme-id ${VERSION}"
+		--variable date="${TODAY}"
+		-o ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
+	DEPENDS ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
+	COMMENT "Generating manpage for azure-nvme-id"
+)
 
 add_custom_target(
         doc ALL

--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -7,22 +7,22 @@ endif()
 string(TIMESTAMP TODAY "%B %d, %Y")
 
 add_custom_command(
-	OUTPUT ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc/azure-nvme-id.1
 	COMMAND ${PANDOC_EXECUTABLE}
 		${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
 		--standalone --from markdown --to man
 		--variable footer="azure-nvme-id ${VERSION}"
 		--variable date="${TODAY}"
-		-o ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.1
+		-o ${CMAKE_CURRENT_BINARY_DIR}/doc/azure-nvme-id.1
 	DEPENDS ${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
 	COMMENT "Generating manpage for azure-nvme-id"
 )
 
 add_custom_target(
         doc ALL
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/doc/azure-nvme-id.1
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/azure-nvme-id.1
 )
 
 set(MANPAGES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/man")
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/doc/azure-nvme-id.1
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/doc/azure-nvme-id.1
         DESTINATION ${MANPAGES_INSTALL_DIR}/man1)


### PR DESCRIPTION
Fix an issue in doc.cmake when pandoc is not available, and move generated file (man page) to binary directory.