### PR TITLE
udev: install udev rules with prefix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
       run: |
         test -f /usr/local/sbin/azure-nvme-id
         test -f /usr/local/share/man/man1/azure-nvme-id.1
-        test -f /lib/udev/rules.d/80-azure-nvme.rules
+        test -f /usr/local/lib/udev/rules.d/80-azure-nvme.rules
         azure-nvme-id --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_compile_options(-Wextra -Wall -Werror -std=gnu11 -D_GNU_SOURCE=1)
 add_executable(azure-nvme-id src/main.c)
 
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
-set(UDEV_RULES_INSTALL_DIR "/lib/udev/rules.d")
+set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d")
 
 option(AZURE_LUN_CALCULATION_BY_NSID_ENABLED "Enable fallback \"LUN\" calculation via NSID" ON)
 if(AZURE_LUN_CALCULATION_BY_NSID_ENABLED)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cmake .
 make
 ```
 
-To install /usr/local/bin/azure-nvme-id and /lib/udev/rules.d/80-azure-nvme.rules:
+To install /usr/local/bin/azure-nvme-id and /usr/local/lib/udev/rules.d/80-azure-nvme.rules:
 
 ```
 sudo make install


### PR DESCRIPTION
Instead of strictly installing to /lib/udev/rules.d, consider the prefix such as "/usr" or "/usr/local".