### PR TITLE
cmake/doc: ensure doc directory exists before invoking pandoc

### DIFF
--- a/cmake/doc.cmake
+++ b/cmake/doc.cmake
@@ -8,6 +8,7 @@ string(TIMESTAMP TODAY "%B %d, %Y")
 
 add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doc/azure-nvme-id.1
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/doc
 	COMMAND ${PANDOC_EXECUTABLE}
 		${CMAKE_SOURCE_DIR}/doc/azure-nvme-id.md
 		--standalone --from markdown --to man


### PR DESCRIPTION
pandoc may error out with openFile() error in some enviornments. Create the directory before generating the output.