### PR TITLE
udev: install rules based on pkg-config variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
       run: |
         test -f /usr/local/sbin/azure-nvme-id
         test -f /usr/local/share/man/man1/azure-nvme-id.1
-        test -f /usr/local/lib/udev/rules.d/80-azure-nvme.rules
+        test -f /lib/udev/rules.d/80-azure-nvme.rules
         azure-nvme-id --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.4.0)
 project(azure-nvme-utils VERSION 0.1.0 LANGUAGES C)
 
 if(NOT DEFINED VERSION)
@@ -9,6 +9,8 @@ if(NOT DEFINED VERSION)
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 endif()
+
+find_package(PkgConfig)
 
 include(cmake/cppcheck.cmake)
 include(cmake/clangformat.cmake)
@@ -22,6 +24,13 @@ add_executable(azure-nvme-id src/main.c)
 
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
 set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d")
+
+if(PKG_CONFIG_FOUND)
+    pkg_get_variable(UDEV_DIR udev udevdir)
+    if(UDEV_DIR)
+        set(UDEV_RULES_INSTALL_DIR "${UDEV_DIR}/rules.d")
+    endif()
+endif()
 
 option(AZURE_LUN_CALCULATION_BY_NSID_ENABLED "Enable fallback \"LUN\" calculation via NSID" ON)
 if(AZURE_LUN_CALCULATION_BY_NSID_ENABLED)


### PR DESCRIPTION
udev is actually [hardcoded](https://github.com/systemd/systemd/blob/ba2caa8a3824011f42b67327917e8285784e016e/src/basic/constants.h#L67) to look for rules under `/etc`, `/run`, `/usr/local/lib`, and `/usr/lib`. Other arbitrary prefixes are not checked. Rather than assume one of these though, let's use the `udevdir` pkg-config variable that is set when installing udev. If this cannot be found, it falls back to the previous behaviour of using the given prefix.

This requires bumping the minimum CMake version to 3.4, but that is nearly 8½ years old now. Even CentOS 7 has a much newer version than this via EPEL.

P.S. If you tag a new release with this, I'll publish an official Gentoo package. :smile: 