### PR TITLE
cmake: Only enable -Werror for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(cmake/doc.cmake)
 include(CTest)
 enable_testing()
 
-add_compile_options(-Wextra -Wall -Werror -std=gnu11 -D_GNU_SOURCE=1)
+add_compile_options(-Wextra -Wall $<$<CONFIG:Debug>:-Werror> -std=gnu11 -D_GNU_SOURCE=1)
 add_executable(azure-nvme-id src/main.c)
 
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")


### PR DESCRIPTION
`-Werror` is very unhelpful for distributions and end users as different (usually newer) compilers will raise warnings that the maintainers may not see. The warnings should get reported upstream, but they shouldn't block users from using the software.

Sorry for not spotting this sooner. I only realised after a Gentoo QA bug was raised against the package. We see issues with `-Werror` all the time!