### PR TITLE
feat(rpm): package %{_mandir}/man8/azure-nvme-id.8.gz

### DIFF
--- a/packaging/fedora/azure-nvme-utils.spec
+++ b/packaging/fedora/azure-nvme-utils.spec
@@ -29,6 +29,7 @@ Utility and udev rules to help identify Azure NVMe devices.
 %files
 %{_exec_prefix}/lib/udev/rules.d/80-azure-nvme.rules
 %{_sbindir}/azure-nvme-id
+%{_mandir}/man8/azure-nvme-id.8.gz
 
 %changelog
 %autochangelog

--- a/packaging/mariner/azure-nvme-utils.spec
+++ b/packaging/mariner/azure-nvme-utils.spec
@@ -32,3 +32,4 @@ Utility and udev rules to help identify Azure NVMe devices.
 %files
 %{_libdir}/udev/rules.d/80-azure-nvme.rules
 %{_sbindir}/azure-nvme-id
+%{_mandir}/man8/azure-nvme-id.8.gz


### PR DESCRIPTION
Now that pandoc isn't required to generate manpage, always package it.