### PR TITLE
feat(udev): drop AZURE_LUN_CALCULATION_BY_NSID_ENABLED option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,6 @@ add_executable(azure-nvme-id src/main.c)
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
 set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "udev rules.d installation directory")
 
-option(AZURE_LUN_CALCULATION_BY_NSID_ENABLED "Enable fallback \"LUN\" calculation via NSID" ON)
-if(AZURE_LUN_CALCULATION_BY_NSID_ENABLED)
-    set(AZURE_LUN_CALCULATION_BY_NSID_ENABLED 1)
-else()
-    set(AZURE_LUN_CALCULATION_BY_NSID_ENABLED 0)
-endif()
-
 configure_file(
   "${PROJECT_SOURCE_DIR}/udev/80-azure-nvme.rules.in"
   "${PROJECT_BINARY_DIR}/udev/80-azure-nvme.rules"

--- a/README.md
+++ b/README.md
@@ -29,26 +29,6 @@ To run in udev mode:
 DEVNAME=/dev/nvme0n1 azure-nvme-id --udev
 ```
 
-### Enabling LUN Calculation by Namespace Identifier (Default)
-
-The "LUN" configured by the user for data disks can be computed by the namespace identifier for "MSFT NVMe Accelerator v1.0" controllers.
-
-This is currently enabled by default to support cases where there is no identification information available in the vendor-specific field of Identify Namespace data structure.
-
-It can be explicitly enabled by passing AZURE_LUN_CALCULATION_BY_NSID_ENABLED=1 to cmake:
-
-```
-cmake -DAZURE_LUN_CALCULATION_BY_NSID_ENABLED=1 .
-```
-
-## Disabling LUN Calculation by Namespace Identifier
-
-Pass AZURE_LUN_CALCULATION_BY_NSID_ENABLED=0 to cmake:
-
-```
-cmake -DAZURE_LUN_CALCULATION_BY_NSID_ENABLED=0 .
-```
-
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/udev/80-azure-nvme.rules.in
+++ b/udev/80-azure-nvme.rules.in
@@ -14,10 +14,8 @@ ATTRS{nsid}=="?*", ENV{AZURE_NVME_TYPE}="local"
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_remote_start"
-ATTRS{nsid}=="?*", ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}="@AZURE_LUN_CALCULATION_BY_NSID_ENABLED@"
-ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ATTRS{nsid}=="1", ENV{AZURE_NVME_TYPE}="os", GOTO="azure_nvme_start"
-ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ATTRS{nsid}=="?*", ENV{AZURE_NVME_TYPE}="data"
-ENV{AZURE_LUN_CALCULATION_BY_NSID_ENABLED}=="1", ENV{AZURE_NVME_TYPE}=="data", ATTRS{nsid}=="?*", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_NVME_LUN}="$result"
+ATTRS{nsid}=="1", ENV{AZURE_NVME_TYPE}="os", GOTO="azure_nvme_start"
+ATTRS{nsid}=="?*", ENV{AZURE_NVME_TYPE}="data", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_NVME_LUN}="$result"
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_start"


### PR DESCRIPTION
Given that this is guaranteed to be supported for Linux OS VMs,
drop the conditional.
    
Consolidate the two udev rule lines that deal with the data disk
while here.  No change of behavior, but with the shorter line length
it seems reasonable to streamline it.