### PR TITLE
feat(udev): drop rules.in template in favor of complete rules file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,4 @@ obj-*
 /build/
 /debian/
 /src/version.h
-/udev/80-azure-nvme.rules
 /out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,18 @@ set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
 set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "udev rules.d installation directory")
 
 configure_file(
-  "${PROJECT_SOURCE_DIR}/udev/80-azure-nvme.rules.in"
-  "${PROJECT_BINARY_DIR}/udev/80-azure-nvme.rules"
-  @ONLY
-)
-
-configure_file(
     "${CMAKE_SOURCE_DIR}/src/version.h.in"
     "${CMAKE_SOURCE_DIR}/src/version.h"
     @ONLY
 )
 
 install(TARGETS azure-nvme-id DESTINATION ${AZURE_NVME_ID_INSTALL_DIR})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/udev/80-azure-nvme.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})
+
+# Install udev rules after updating "/usr/sbin/azure-nvme-id" with installed path $AZURE_NVME_ID_INSTALL_DIR.
+file(READ ${CMAKE_SOURCE_DIR}/udev/80-azure-nvme.rules CONTENT)
+string(REPLACE "/usr/sbin/azure-nvme-id" "${AZURE_NVME_ID_INSTALL_DIR}/azure-nvme-id" CONTENT "${CONTENT}")
+file(WRITE ${CMAKE_BINARY_DIR}/udev/80-azure-nvme.rules ${CONTENT})
+install(FILES ${CMAKE_BINARY_DIR}/udev/80-azure-nvme.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/udev/80-azure-nvme.rules
+++ b/udev/80-azure-nvme.rules
@@ -19,7 +19,7 @@ ATTRS{nsid}=="?*", ENV{AZURE_NVME_TYPE}="data", PROGRAM="/bin/sh -ec 'echo $$((%
 GOTO="azure_nvme_start"
 
 LABEL="azure_nvme_start"
-ATTRS{nsid}=="?*", IMPORT{program}="@AZURE_NVME_ID_INSTALL_DIR@/azure-nvme-id --udev"
+ATTRS{nsid}=="?*", IMPORT{program}="/usr/sbin/azure-nvme-id --udev"
 # systemd v254 ships an updated 60-persistent-storage.rules that would allow
 # these to be deduplicated using $env{.PART_SUFFIX}
 ENV{DEVTYPE}=="disk", ENV{AZURE_NVME_TYPE}=="os", SYMLINK+="disk/azure/os"


### PR DESCRIPTION
Instead of generating the rules from a template with variables, replace @AZURE_NVME_ID_INSTALL_DIR@ with a hardcoded /usr/sbin path. To ensure the path is correct during a build, replace the string as needed.

This allows the rules to be copied in the majority of cases while still ensuring the correct rules file is produced during a build.