### PR TITLE
feat(initramfs): add configuration for dracut & initramfs-tools

### DIFF
--- a/.github/workflows/debs.yml
+++ b/.github/workflows/debs.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         set -x
         dpkg -L azure-nvme-utils
+        test -f /usr/share/initramfs-tools/hooks/azure-disk
         test -f /usr/share/man/man8/azure-nvme-id.8.gz
         test -f /usr/sbin/azure-nvme-id
         test -f /lib/udev/rules.d/80-azure-disk.rules

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Prerequisites
-*.d
-
 # Object files
 *.o
 *.ko

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ add_compile_options(-Wextra -Wall $<$<CONFIG:Debug>:-Werror> -std=gnu11 -D_GNU_S
 add_executable(azure-nvme-id src/main.c)
 
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin")
+set(DRACUT_MODULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/dracut/modules.d/97azure-disk" CACHE PATH "dracut modules installation directory")
+set(INITRAMFS_HOOKS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/initramfs-tools/hooks" CACHE PATH "initramfs-tools hooks installation directory")
 set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "udev rules.d installation directory")
 
 configure_file(
@@ -36,6 +38,23 @@ file(READ ${CMAKE_SOURCE_DIR}/udev/80-azure-disk.rules CONTENT)
 string(REPLACE "/usr/sbin/azure-nvme-id" "${AZURE_NVME_ID_INSTALL_DIR}/azure-nvme-id" CONTENT "${CONTENT}")
 file(WRITE ${CMAKE_BINARY_DIR}/udev/80-azure-disk.rules ${CONTENT})
 install(FILES ${CMAKE_BINARY_DIR}/udev/80-azure-disk.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})
+
+find_program(INITRAMFS_TOOLS update-initramfs)
+find_program(DRACUT dracut)
+if(INITRAMFS_TOOLS AND INITRAMFS_HOOKS_INSTALL_DIR)
+    message(STATUS "initramfs-tools found, installing initramfs hook")
+    set(HOOK_SCRIPT ${CMAKE_SOURCE_DIR}/initramfs/initramfs-tools/hooks/azure-disk)
+    install(FILES ${HOOK_SCRIPT}
+        DESTINATION ${INITRAMFS_HOOKS_INSTALL_DIR}
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
+elseif(DRACUT AND DRACUT_MODULES_INSTALL_DIR)
+    message(STATUS "dracut found, installing dracut module")
+    install(FILES ${CMAKE_SOURCE_DIR}/initramfs/dracut/modules.d/97azure-disk/module-setup.sh
+        DESTINATION ${DRACUT_MODULES_INSTALL_DIR}
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
+else()
+    message(STATUS "initramfs-tools and dracut not found, skipping installation of azure-disk hook")
+endif()
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/initramfs/dracut/modules.d/97azure-disk/module-setup.sh
+++ b/initramfs/dracut/modules.d/97azure-disk/module-setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+install() {
+    inst_multiple azure-nvme-id cut readlink
+    inst_rules 80-azure-disk.rules
+}

--- a/initramfs/initramfs-tools/hooks/azure-disk
+++ b/initramfs/initramfs-tools/hooks/azure-disk
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+PREREQ="udev"
+
+prereqs()
+{
+    echo "${PREREQ}"
+}
+
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+DESTINATION="${DESTDIR}/lib/udev/rules.d/"
+RULES_FILE="/usr/lib/udev/rules.d/80-azure-disk.rules"
+
+if [ -e "${RULES_FILE}" ]; then
+    mkdir -p "${DESTINATION}"
+    cp -p "${RULES_FILE}" "${DESTINATION}"
+fi
+
+copy_exec "/usr/bin/cut" "${DESTDIR}/bin/"
+copy_exec "/usr/bin/readlink" "${DESTDIR}/bin/"
+copy_exec "/usr/sbin/azure-nvme-id" "${DESTDIR}/sbin/"

--- a/packaging/fedora/azure-nvme-utils.spec
+++ b/packaging/fedora/azure-nvme-utils.spec
@@ -27,6 +27,7 @@ Utility and udev rules to help identify Azure NVMe devices.
 %ctest
 
 %files
+%{_exec_prefix}/lib/dracut/modules.d/97azure-disk/module-setup.sh
 %{_exec_prefix}/lib/udev/rules.d/80-azure-disk.rules
 %{_sbindir}/azure-nvme-id
 %{_mandir}/man8/azure-nvme-id.8.gz

--- a/packaging/mariner/azure-nvme-utils.spec
+++ b/packaging/mariner/azure-nvme-utils.spec
@@ -30,6 +30,7 @@ Utility and udev rules to help identify Azure NVMe devices.
 %ctest
 
 %files
+%{_libdir}/dracut/modules.d/97azure-disk/module-setup.sh
 %{_libdir}/udev/rules.d/80-azure-disk.rules
 %{_sbindir}/azure-nvme-id
 %{_mandir}/man8/azure-nvme-id.8.gz


### PR DESCRIPTION
Some images may require an initramfs hook for the udev rules to
properly function.

Provide an initramfs hook & dracut module configuration for
distributions to use, if desired.  Choose which to install based
on detection of `update-initramfs` or `dracut`.