### PR TITLE
fix(main): exit with 0 if no NVMe devices are found

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -291,8 +291,8 @@ int enumerate_azure_nvme_controllers()
     int n = scandir(SYS_CLASS_NVME_PATH, &namelist, is_azure_nvme_controller, alphasort);
     if (n < 0)
     {
-        fprintf(stderr, "no NVMe devices found in %s\n", SYS_CLASS_NVME_PATH);
-        return 1;
+        fprintf(stderr, "no NVMe devices in %s: %m\n", SYS_CLASS_NVME_PATH);
+        return 0;
     }
 
     DEBUG_PRINTF("found %d controllers\n", n);


### PR DESCRIPTION
/sys/class/nvme may not be available in some images when there are no NVMe devices, such as Mariner 2.  This is an expected case, so return 0 instead of 1.

Add %m to indicate the error returned by scandir in case it's relevant.  Should now look like:

```
no NVMe devices in /sys/class/nvme: No such file or directory
```