### PR TITLE
feat(rename): azure-nvme-utils -> azure-vm-utils

### DIFF
--- a/.github/workflows/debs.yml
+++ b/.github/workflows/debs.yml
@@ -20,9 +20,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
     - name: Get tags from upstream, if needed
-      if: github.repository != 'Azure/azure-nvme-utils'
+      if: github.repository != 'Azure/azure-vm-utils'
       run: |
-        git remote add upstream https://github.com/Azure/azure-nvme-utils.git
+        git remote add upstream https://github.com/Azure/azure-vm-utils.git
         git fetch upstream --tags
     - name: Setup
       run: |
@@ -30,7 +30,7 @@ jobs:
         sudo apt install gcc pandoc cmake devscripts debhelper -y
     - name: Build debs
       run: |
-        DEBEMAIL="Azure NVMe Utils CI <azure/azure-nvme-utils@github.com>" ./scripts/build-deb.sh
+        DEBEMAIL="Azure VM Utils CI <azure/azure-vm-utils@github.com>" ./scripts/build-deb.sh
     - name: Lintian check
       run: |
         lintian out/*.deb
@@ -40,7 +40,7 @@ jobs:
     - name: Verify installation
       run: |
         set -x
-        dpkg -L azure-nvme-utils
+        dpkg -L azure-vm-utils
         test -f /usr/share/initramfs-tools/hooks/azure-disk
         test -f /usr/share/man/man8/azure-nvme-id.8.gz
         test -f /usr/sbin/azure-nvme-id

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
     - name: Get tags from upstream, if needed
-      if: github.repository != 'Azure/azure-nvme-utils'
+      if: github.repository != 'Azure/azure-vm-utils'
       run: |
-        git remote add upstream https://github.com/Azure/azure-nvme-utils.git
+        git remote add upstream https://github.com/Azure/azure-vm-utils.git
         git fetch upstream --tags
     - name: Setup
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(azure-nvme-utils VERSION 0.1.0 LANGUAGES C)
+project(azure-vm-utils VERSION 0.1.0 LANGUAGES C)
 
 if(NOT DEFINED VERSION)
     execute_process(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Project
+# azure-vm-utils
 
-This project includes a utility to help identify Azure NVMe devices.
+A collection of utilities and udev rules to make the most of the Linux experience on Azure.
 
 ## Quick Start
 
@@ -11,11 +11,17 @@ cmake .
 make
 ```
 
-To install /usr/local/bin/azure-nvme-id and /usr/local/lib/udev/rules.d/80-azure-disk.rules:
+To install:
 
 ```
 sudo make install
 ```
+
+# Executables
+
+## azure-nvme-id
+
+`azure-nvme-id` is a utility to help identify Azure NVMe devices.
 
 To run:
 
@@ -29,7 +35,13 @@ To run in udev mode:
 DEVNAME=/dev/nvme0n1 azure-nvme-id --udev
 ```
 
-## Contributing
+# Rules for udev
+
+## 80-azure-disk.rules
+
+Provides helpful symlinks in /dev/disk/azure for local, data, and os disks.
+
+# Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/doc/azure-nvme-id.8
+++ b/doc/azure-nvme-id.8
@@ -50,5 +50,5 @@ azure\-nvme\-id 0.1.2
 .EE
 .SH SEE ALSO
 Source and documentation available at: \c
-.UR https://github.com/Azure/azure-nvme-utils
+.UR https://github.com/Azure/azure-vm-utils
 .UE \c

--- a/doc/azure-nvme-id.md
+++ b/doc/azure-nvme-id.md
@@ -63,4 +63,4 @@ azure-nvme-id 0.1.2
 
 # SEE ALSO
 
-Source and documentation available at: <https://github.com/Azure/azure-nvme-utils>
+Source and documentation available at: <https://github.com/Azure/azure-vm-utils>

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,16 +1,15 @@
-Source: azure-nvme-utils
+Source: azure-vm-utils
 Section: utils
 Priority: optional
 Maintainer: Chris Patterson <cpatterson@microsoft.com>
 Build-Depends: cmake, pandoc, debhelper-compat (= 12)
 Standards-Version: 4.5.0
-Homepage: https://github.com/Azure/azure-nvme-utils
+Homepage: https://github.com/Azure/azure-vm-utils
 Rules-Requires-Root: no
 
-Package: azure-nvme-utils
+Package: azure-vm-utils
 Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: Utilities to assist managing NVMe devices on Azure
- This package provides azure-nvme-id for NVMe device identification and udev
- rules to provide symlinks using available identifiers.
+Description: A collection of utilities and udev rules to make the most of the
+ Linux experience on Azure.

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: azure-nvme-utils
-Upstream-Contact: https://github.com/Azure/azure-nvme-utils/issues
-Source: https://github.com/Azure/azure-nvme-utils
+Upstream-Name: azure-vm-utils
+Upstream-Contact: https://github.com/Azure/azure-vm-utils/issues
+Source: https://github.com/Azure/azure-vm-utils
 
 Files: *
 Copyright: 2024 Microsoft Corporation

--- a/packaging/fedora/azure-vm-utils.spec
+++ b/packaging/fedora/azure-vm-utils.spec
@@ -1,7 +1,7 @@
-Name:           azure-nvme-utils
+Name:           azure-vm-utils
 Version:        %{__git_version}
 Release:        %{__git_release}%{?dist}
-Summary:        Utility and udev rules to help identify Azure NVMe devices
+Summary:        Utilities and udev rules for Linux on Azure
 
 License:        MIT
 URL:            https://github.com/Azure/%{name}
@@ -11,7 +11,8 @@ BuildRequires:  cmake
 BuildRequires:  gcc
 
 %description
-Utility and udev rules to help identify Azure NVMe devices.
+A collection of utilities and udev rules to make the most of the Linux
+experience on Azure.
 
 %prep
 %autosetup

--- a/packaging/mariner/azure-vm-utils.spec
+++ b/packaging/mariner/azure-vm-utils.spec
@@ -1,11 +1,11 @@
-Name:           azure-nvme-utils
+Name:           azure-vm-utils
 Version:        %{__git_version}
 Release:        %{__git_release}%{?dist}
-Summary:        Utility and udev rules to help identify Azure NVMe devices
+Summary:        Utilities and udev rules for Linux on Azure
 
 License:        MIT
 URL:            https://github.com/Azure/%{name}
-Source0:        azure-nvme-utils_dev.tgz
+Source0:        azure-vm-utils_dev.tgz
 
 BuildRequires:  binutils
 BuildRequires:  cmake
@@ -14,7 +14,8 @@ BuildRequires:  glibc-devel
 BuildRequires:  kernel-headers
 
 %description
-Utility and udev rules to help identify Azure NVMe devices.
+A collection of utilities and udev rules to make the most of the Linux
+experience on Azure.
 
 %prep
 %autosetup

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -21,10 +21,10 @@ if [[ -z ${DEBEMAIL:-} ]]; then
     git_email="$(git config user.email)"
     export DEBEMAIL="${git_user} <${git_email}>"
 fi
-dch --create -v "${deb_version}" --package "azure-nvme-utils" "development build: ${git_version}"
+dch --create -v "${deb_version}" --package "azure-vm-utils" "development build: ${git_version}"
 
 debuild --no-tgz-check
 
 mkdir -p "${output_dir}"
 rm -f "${output_dir}"/*.deb
-mv ../azure-nvme-utils*"${deb_version}"* "${output_dir}"/
+mv ../azure-vm-utils*"${deb_version}"* "${output_dir}"/

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -21,20 +21,20 @@ build_dir="$(mktemp -d)"
 mkdir -p "${build_dir}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 # Create source tarball.
-output_source="${build_dir}/SOURCES/azure-nvme-utils_dev.tgz"
+output_source="${build_dir}/SOURCES/azure-vm-utils_dev.tgz"
 cd "$project_dir"
-git archive --verbose --format=tar.gz --prefix="azure-nvme-utils-${version}/" HEAD --output "${output_source}"
+git archive --verbose --format=tar.gz --prefix="azure-vm-utils-${version}/" HEAD --output "${output_source}"
 
 # Create spec file from template.
 cd "${project_dir}/packaging/${distro}"
 
 # Install dependencies.
-sudo dnf builddep -y --spec azure-nvme-utils.spec
+sudo dnf builddep -y --spec azure-vm-utils.spec
 
 # Build RPM.
-rpmbuild -ba --define "__git_version ${version}" --define "__git_release ${release}" --define "_topdir ${build_dir}" azure-nvme-utils.spec
+rpmbuild -ba --define "__git_version ${version}" --define "__git_release ${release}" --define "_topdir ${build_dir}" azure-vm-utils.spec
 
 # Copy RPM to output directory.
 mkdir -p "${output_dir}"
 rm -f "${output_dir}"/*.rpm
-cp -v "${build_dir}"/RPMS/*/"azure-nvme-utils-${version}-${release}".*.rpm "${output_dir}"
+cp -v "${build_dir}"/RPMS/*/"azure-vm-utils-${version}-${release}".*.rpm "${output_dir}"


### PR DESCRIPTION
To support expansion of scope for future utilities and udev rules outside of NVMe support, rename azure-nvme-utils to azure-vm-utils.