### PR TITLE
chore(cmake): set minimum version to 3.5 to avoid deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.5)
 project(azure-vm-utils VERSION 0.1.0 LANGUAGES C)
 
 if(NOT DEFINED VERSION)


### PR DESCRIPTION
It's a little unclear exactly what it should be, but 3.5 will at least silence the warnings.  Most distros should be offering an option or we sort out patches as needed.