### PR TITLE
chore(gitignore): drop /debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,5 @@ _deps
 azure-nvme-id
 obj-*
 /build/
-/debian/
 /src/version.h
 /out/


### PR DESCRIPTION
Allows us to drop a patch for debian packaging.  It isn't really needed in the repository as it's not a common artifact unless using the build-deb script.