### PR TITLE
fix(build-rpm): remove builddep in favor of simple grep

### DIFF
--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -29,7 +29,8 @@ git archive --verbose --format=tar.gz --prefix="azure-vm-utils-${version}/" HEAD
 cd "${project_dir}/packaging/${distro}"
 
 # Install dependencies.
-sudo dnf builddep -y --spec azure-vm-utils.spec
+build_requirements=$(grep ^BuildRequires azure-vm-utils.spec | awk '{{print $2}}' | tr '\n' ' ')
+sudo dnf install -y ${build_requirements}
 
 # Build RPM.
 rpmbuild -ba --define "__git_version ${version}" --define "__git_release ${release}" --define "_topdir ${build_dir}" azure-vm-utils.spec


### PR DESCRIPTION
dnf builddep interfaces changed between fedora 40 and 41 where --spec is dropped.  Instead of trying to guess the right interface for the OS, just grep the build requirements from the spec and install them.