### PR TITLE
fix(query_namespace_vs): set correct data_len for nvme_id_ns struct

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -201,7 +201,7 @@ char *query_namespace_vs(const char *namespace_path)
         .opcode = 0x06, // Identify command
         .nsid = nsid,
         .addr = (unsigned long)ns,
-        .data_len = sizeof(ns),
+        .data_len = sizeof(struct nvme_id_ns),
     };
 
     if (ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd) < 0)

--- a/src/main.c
+++ b/src/main.c
@@ -201,7 +201,7 @@ char *query_namespace_vs(const char *namespace_path)
         .opcode = 0x06, // Identify command
         .nsid = nsid,
         .addr = (unsigned long)ns,
-        .data_len = sizeof(struct nvme_id_ns),
+        .data_len = sizeof(*ns),
     };
 
     if (ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd) < 0)


### PR DESCRIPTION
sizeof(ns) is 4 because ns is a pointer.  Fix it to be the correct size of the struct.

It is interesting that it has worked without issue.  There must be some page-sized rounding that prevented issues.