### PR TITLE
feat(azure-nvme-id): identify MSFT NVMe Accelerator v1.0 disks

### DIFF
--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -468,6 +468,7 @@ class AzureNvmeIdDevice:
     nvme_id: str
     type: Optional[str]
     index: Optional[int]
+    lun: Optional[str]
     name: Optional[str]
     extra: Dict[str, str]
 
@@ -513,23 +514,41 @@ class AzureNvmeIdInfo:
             ), f"missing azure-nvme-id for {device_name}"
             disk_cfg = self.azure_nvme_id_disks.get(device_name)
             assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
-            assert disk_cfg.type == "local", "unexpected local disk type {disk_cfg}"
-            assert disk_cfg.name, "unexpected local disk name {disk_cfg}"
-            assert disk_cfg.index, "unexpected local disk index {disk_cfg}"
-            assert disk_cfg.nvme_id, "unexpected local disk id {disk_cfg}"
-            assert not disk_cfg.extra, "unexpected local disk extra {disk_cfg}"
+            assert disk_cfg.type == "local", f"unexpected local disk type {disk_cfg}"
+            assert disk_cfg.name, f"unexpected local disk name {disk_cfg}"
+            assert disk_cfg.index, f"unexpected local disk index {disk_cfg}"
+            assert disk_cfg.nvme_id, f"unexpected local disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected local disk extra {disk_cfg}"
 
-        for device_name in disk_info.nvme_remote_disks + disk_info.nvme_local_disks_v1:
+        for device_name in disk_info.nvme_local_disks_v1:
             assert (
                 device_name in self.azure_nvme_id_disks
             ), f"missing azure-nvme-id for {device_name}"
             disk_cfg = self.azure_nvme_id_disks.get(device_name)
             assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
-            assert not disk_cfg.type, "unexpected disk type {disk_cfg}"
-            assert not disk_cfg.name, "unexpected disk name {disk_cfg}"
-            assert not disk_cfg.index, "unexpected disk index {disk_cfg}"
-            assert not disk_cfg.nvme_id, "unexpected disk id {disk_cfg}"
-            assert not disk_cfg.extra, "unexpected disk extra {disk_cfg}"
+            assert not disk_cfg.type, f"unexpected disk type {disk_cfg}"
+            assert not disk_cfg.name, f"unexpected disk name {disk_cfg}"
+            assert not disk_cfg.index, f"unexpected disk index {disk_cfg}"
+            assert not disk_cfg.nvme_id, f"unexpected disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected disk extra {disk_cfg}"
+
+        for device_name in disk_info.nvme_remote_disks:
+            assert (
+                device_name in self.azure_nvme_id_disks
+            ), f"missing azure-nvme-id for {device_name}"
+            disk_cfg = self.azure_nvme_id_disks.get(device_name)
+            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
+            assert disk_cfg.type in (
+                "os",
+                "data",
+            ), f"unexpected remote disk type {disk_cfg}"
+            if disk_cfg.type == "data":
+                assert disk_cfg.lun, f"unexpected remote disk index {disk_cfg}"
+            else:
+                assert not disk_cfg.lun, f"unexpected remote disk index {disk_cfg}"
+            assert not disk_cfg.name, f"unexpected remote disk name {disk_cfg}"
+            assert disk_cfg.nvme_id, f"unexpected remote disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected remote disk extra {disk_cfg}"
 
         logger.info("validate_azure_nvmve_id: OK")
 
@@ -593,11 +612,12 @@ class AzureNvmeIdInfo:
         """Parse azure-nvme-id output.
 
         Example output:
-        /dev/nvme0n1:
-        /dev/nvme0n2:
-        /dev/nvme0n3:
+        /dev/nvme0n1: type=os
+        /dev/nvme0n2: type=data,lun=0
+        /dev/nvme0n3: type=data,lun=1
         /dev/nvme1n1: type=local,index=1,name=nvme-440G-1
         /dev/nvme2n1: type=local,index=2,name=nvme-440G-2
+        /dev/nvme3n1:
         """
         devices = {}
 
@@ -620,12 +640,14 @@ class AzureNvmeIdInfo:
             device_index = (
                 int(properties.pop("index")) if "index" in properties else None
             )
+            device_lun = properties.pop("lun", None)
             device_name = properties.pop("name", None)
             azure_nvme_id_device = AzureNvmeIdDevice(
                 device=device,
                 nvme_id=nvme_id,
                 type=device_type,
                 index=device_index,
+                lun=device_lun,
                 name=device_name,
                 extra=properties,
             )

--- a/src/identify_disks.h
+++ b/src/identify_disks.h
@@ -28,6 +28,7 @@ struct nvme_controller
     char model[MAX_PATH];
 };
 
+void trim_trailing_whitespace(char *str);
 int is_microsoft_nvme_device(const char *device_name);
 int is_nvme_namespace(const struct dirent *entry);
 int enumerate_namespaces_for_controller(struct nvme_controller *ctrl);


### PR DESCRIPTION
These disks do not support vendor-specific id but is used for all v6 VM sizes.  For usability, show the type and lun in the same manner as we do in the udev rules.

Note that this does not change the udev rules. azure-nvme-id will not be invoked for this controller as there is no benefit to the cost of performing IDENTIFY_NAMESPACE on these namespaces at this time.  This may change in the future.

This leaves Microsoft NVMe Direct Disk (v1) without identification information, but that's limited to older skus.  In this case there is no alternative to provide a predictable name or index.  The udev rules will continue to map them by id.

Fix some missing f-strings in selftest too.