### PR TITLE
feat(azure-nvme-id): identify disks without vendor-specific id

### DIFF
--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -1,4 +1,10 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license
+ * information.
+ */
 
+#include <ctype.h>
 #include <dirent.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -10,6 +16,18 @@
 #include "nvme.h"
 
 /**
+ * Trim trailing whitespace from a string in-place.
+ */
+void trim_trailing_whitespace(char *str)
+{
+    size_t len = strlen(str);
+    while (len > 0 && isspace((unsigned char)str[len - 1]))
+    {
+        str[--len] = '\0'; // Replace trailing whitespace with null terminator
+    }
+}
+
+/**
  * Callback for scandir() to filter for NVMe namespaces.
  */
 int is_nvme_namespace(const struct dirent *entry)
@@ -19,6 +37,64 @@ int is_nvme_namespace(const struct dirent *entry)
 
     // Check for NVME controller name format: nvme<ctrl id>n<ns id>
     return sscanf(entry->d_name, "nvme%un%u%c", &ctrl, &nsid, &p) == 2;
+}
+
+/**
+ * Identify namespace without using vendor-specific command set.
+ * Used as a fallback when vendor-specific command set is not supported.
+ */
+char *identify_namespace_without_vs(const char *controller_sys_path, const char *namespace_path)
+{
+    char model_name[MAX_PATH] = {0};
+    char model_path[MAX_PATH];
+    snprintf(model_path, sizeof(model_path), "%s/model", controller_sys_path);
+
+    FILE *file = fopen(model_path, "r");
+    if (file == NULL)
+    {
+        DEBUG_PRINTF("failed to open %s: %m\n", model_path);
+        return strdup("");
+    }
+
+    char *result = fgets(model_name, sizeof(model_name), file);
+    if (result == NULL)
+    {
+        DEBUG_PRINTF("failed to read model name from %s: %m\n", model_path);
+        fclose(file);
+        return strdup("");
+    }
+
+    fclose(file);
+
+    trim_trailing_whitespace(model_name);
+    DEBUG_PRINTF("read model name=\"%s\"\n", model_name);
+
+    if (strcmp(model_name, "MSFT NVMe Accelerator v1.0") == 0)
+    {
+        // Microsoft Azure NVMe Accelerator v1.0 supports remote OS and data disks.
+        // nsid=1 is the OS disk and nsid=2+ for data disks.
+        // A data disk's lun id == nsid - 2.
+        int nsid = get_nsid_from_namespace_device_path(namespace_path);
+        if (nsid == 1)
+        {
+            return strdup("type=os");
+        }
+        else
+        {
+            char *output = NULL;
+            if (asprintf(&output, "type=data,lun=%d", nsid - 2) > 0)
+            {
+                return output;
+            }
+        }
+    }
+    else if (strcmp(model_name, "Microsoft NVMe Direct Disk") == 0 ||
+             strcmp(model_name, "Microsoft NVMe Direct Disk v2") == 0)
+    {
+        return strdup("type=local");
+    }
+
+    return strdup("");
 }
 
 /**
@@ -44,6 +120,12 @@ int enumerate_namespaces_for_controller(struct nvme_controller *ctrl)
         char *vs = nvme_identify_namespace_vs_for_namespace_device(namespace_path);
         if (vs != NULL)
         {
+            if (vs[0] == 0)
+            {
+                free(vs);
+                vs = identify_namespace_without_vs(ctrl->sys_path, namespace_path);
+            }
+
             printf("%s: %s\n", namespace_path, vs);
             free(vs);
         }

--- a/src/identify_disks.h
+++ b/src/identify_disks.h
@@ -28,6 +28,7 @@ struct nvme_controller
     char model[MAX_PATH];
 };
 
+void trim_trailing_whitespace(char *str);
 int is_microsoft_nvme_device(const char *device_name);
 int is_nvme_namespace(const struct dirent *entry);
 int enumerate_namespaces_for_controller(struct nvme_controller *ctrl);

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -1,6 +1,7 @@
 #include <dirent.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,6 +15,10 @@
 
 #include "capture.h"
 #include "identify_disks.h"
+
+#define MICROSOFT_NVME_DIRECT_DISK_V1 "Microsoft NVMe Direct Disk              \n"
+#define MICROSOFT_NVME_DIRECT_DISK_V2 "Microsoft NVMe Direct Disk v2           \n"
+#define MSFT_NVME_ACCELERATOR_MODEL_V1 "MSFT NVMe Accelerator v1.0              \n"
 
 char *fake_sys_class_nvme_path = "/sys/class/nvme";
 
@@ -130,6 +135,184 @@ static int teardown(void **state)
     return 0;
 }
 
+/**
+ * Setup nvme0: microsoft disk controler, no namespaces.
+ */
+static void _setup_nvme0_microsoft_no_name_namespaces(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme0/device/vendor", "0x1414");
+
+    // nothing to expect as no namespaces are iterated through.
+}
+
+/**
+ * Setup nvme1: microsoft disk, one namespace.
+ */
+static void _setup_nvme1_microsoft_one_namespace(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme1/device/vendor", "0x1414");
+    create_dir(fake_sys_class_nvme_path, "nvme1/nvme1n1");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme1n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme1n1value1,key2=nvme1n1value2"));
+}
+
+/**
+ * Setup nvme2: microsoft disk, two namespaces.
+ */
+static void _setup_nvme2_microsoft_two_namespaces(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme2/device/vendor", "0x1414");
+    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n1");
+    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n2");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme2n1value1,key2=nvme2n1value2"));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n2");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme2n2value1,key2=nvme2n2value2"));
+}
+
+// No nvme3.
+
+/**
+ * Setup nvme4: non-microsoft disk.
+ */
+static void _setup_nvme4_non_microsoft(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme4/device/vendor", "0x0000");
+    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n1");
+    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n2");
+}
+
+/**
+ * Setup nvme5: microsoft disk, empty vs for nsid=2, error on nsid=3.
+ */
+static void _setup_nvme5_microsoft_mixed_namespaces(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme5/device/vendor", "0x1414");
+    create_file(fake_sys_class_nvme_path, "nvme5/model", "Unknown model");
+    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n1");
+    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n2");
+    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n3");
+    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n4");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme5n1value1,key2=nvme5n1value2"));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n2");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n3");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, NULL);
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n4");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme5n4value1,key2=nvme5n4value2"));
+}
+
+/**
+ * Setup nvme6: remote accelerator v1 with vs.
+ */
+static void _setup_nvme6_remote_accelerator_v1_with_vs(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme6/device/vendor", "0x1414");
+    create_dir(fake_sys_class_nvme_path, "nvme6/nvme6n1");
+    create_file(fake_sys_class_nvme_path, "nvme6/model", MSFT_NVME_ACCELERATOR_MODEL_V1);
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme6n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme6n1value1,key2=nvme6n1value2"));
+}
+
+/**
+ * Setup nvme7: remote accelerator v1 without vs.
+ */
+static void _setup_nvme7_remote_accelerator_v1_without_vs(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme7/device/vendor", "0x1414");
+    create_file(fake_sys_class_nvme_path, "nvme7/model", MSFT_NVME_ACCELERATOR_MODEL_V1);
+    create_dir(fake_sys_class_nvme_path, "nvme7/nvme7n1");
+    create_dir(fake_sys_class_nvme_path, "nvme7/nvme7n2");
+    create_dir(fake_sys_class_nvme_path, "nvme7/nvme7n3");
+    create_dir(fake_sys_class_nvme_path, "nvme7/nvme7n4");
+    create_dir(fake_sys_class_nvme_path, "nvme7/nvme7n9");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme7n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme7n2");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme7n3");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme7n4");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme7n9");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+}
+
+/**
+ * Setup nvme8: direct disk v1 which doesn't have vs support.
+ */
+static void _setup_nvme8_direct_disk_v1_without_vs(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme8/device/vendor", "0x1414");
+    create_file(fake_sys_class_nvme_path, "nvme8/model", MICROSOFT_NVME_DIRECT_DISK_V1);
+    create_dir(fake_sys_class_nvme_path, "nvme8/nvme8n1");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme8n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+}
+
+/**
+ * Setup nvme9: direct disk v2 which has vs support.
+ */
+static void _setup_nvme9_direct_disk_v2(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme9/device/vendor", "0x1414");
+    create_file(fake_sys_class_nvme_path, "nvme9/model", MICROSOFT_NVME_DIRECT_DISK_V2);
+    create_dir(fake_sys_class_nvme_path, "nvme9/nvme9n1");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme9n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
+                strdup("key1=nvme9n1value1,key2=nvme9n1value2"));
+}
+
+/**
+ * Setup nvme10: direct disk v2 which is missing vs support (unexpected case).
+ */
+static void _setup_nvme10_direct_disk_v2_missing_vs(void)
+{
+    create_file(fake_sys_class_nvme_path, "nvme10/device/vendor", "0x1414");
+    create_file(fake_sys_class_nvme_path, "nvme10/model", MICROSOFT_NVME_DIRECT_DISK_V2);
+    create_dir(fake_sys_class_nvme_path, "nvme10/nvme10n1");
+
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme10n1");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
+}
+
+static void test_trim_trailing_whitespace(void **state)
+{
+    (void)state; // Unused parameter
+
+    struct
+    {
+        char input[MAX_PATH];
+        char expected[MAX_PATH];
+    } test_cases[] = {{"NoTrailingWhitespace", "NoTrailingWhitespace"},
+                      {"TrailingSpaces   ", "TrailingSpaces"},
+                      {"TrailingTabs\t\t\t", "TrailingTabs"},
+                      {"TrailingNewline\n", "TrailingNewline"},
+                      {"TrailingMixed   \t\n", "TrailingMixed"},
+                      {"", ""},
+                      {"\0", "\0"}};
+
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++)
+    {
+        trim_trailing_whitespace(test_cases[i].input);
+        assert_string_equal(test_cases[i].input, test_cases[i].expected);
+    }
+}
+
 static void test_identify_disks_no_sys_class_nvme_present(void **state)
 {
     (void)state; // Unused parameter
@@ -140,197 +323,101 @@ static void test_identify_disks_no_sys_class_nvme_present(void **state)
     remove_temp_dir(fake_sys_class_nvme_path);
 
     int result = identify_disks();
-
     assert_int_equal(result, 0);
     assert_string_equal(capture_stderr(), expected_string);
     assert_string_equal(capture_stdout(), "");
 }
 
-static void test_identify_disks_no_nvme_devices(void **state)
+static void test_identify_disks(void **state)
 {
-    (void)state; // Unused parameter
+    struct
+    {
+        const char *name;
+        void (*setup_func)(void);
+        const char *expected_stderr;
+        const char *expected_stdout;
+    } test_cases[] = {
+        {"no namespaces", NULL, "", ""},
+        {"nvme0", _setup_nvme0_microsoft_no_name_namespaces, "", ""},
+        {"nvme1", _setup_nvme1_microsoft_one_namespace, "", "/dev/nvme1n1: key1=nvme1n1value1,key2=nvme1n1value2\n"},
+        {"nvme2", _setup_nvme2_microsoft_two_namespaces, "",
+         "/dev/nvme2n1: key1=nvme2n1value1,key2=nvme2n1value2\n"
+         "/dev/nvme2n2: key1=nvme2n2value1,key2=nvme2n2value2\n"},
+        {"nvme4", _setup_nvme4_non_microsoft, "", ""},
+        {"nvme5", _setup_nvme5_microsoft_mixed_namespaces, "",
+         "/dev/nvme5n1: key1=nvme5n1value1,key2=nvme5n1value2\n"
+         "/dev/nvme5n2: \n"
+         "/dev/nvme5n4: key1=nvme5n4value1,key2=nvme5n4value2\n"},
+        {"nvme6", _setup_nvme6_remote_accelerator_v1_with_vs, "",
+         "/dev/nvme6n1: key1=nvme6n1value1,key2=nvme6n1value2\n"},
+        {"nvme7", _setup_nvme7_remote_accelerator_v1_without_vs, "",
+         "/dev/nvme7n1: type=os\n"
+         "/dev/nvme7n2: type=data,lun=0\n"
+         "/dev/nvme7n3: type=data,lun=1\n"
+         "/dev/nvme7n4: type=data,lun=2\n"
+         "/dev/nvme7n9: type=data,lun=7\n"},
+        {"nvme8", _setup_nvme8_direct_disk_v1_without_vs, "", "/dev/nvme8n1: type=local\n"},
+        {"nvme9", _setup_nvme9_direct_disk_v2, "", "/dev/nvme9n1: key1=nvme9n1value1,key2=nvme9n1value2\n"},
+        {"nvme10", _setup_nvme10_direct_disk_v2_missing_vs, "", "/dev/nvme10n1: type=local\n"}};
 
-    int result = identify_disks();
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++)
+    {
+        printf("Running test case: %s\n", test_cases[i].name);
+        teardown(state);
+        setup(state);
 
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "");
-}
+        if (test_cases[i].setup_func)
+            test_cases[i].setup_func();
 
-static void test_identify_disks_vs_error(void **state)
-{
-    (void)state; // Unused parameter
-
-    // nvme5: microsoft disk, empty vs for nsid=2, error on nsid=3 (should be
-    // skipped)
-    create_file(fake_sys_class_nvme_path, "nvme5/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n1");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n2");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n3");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n4");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme5n1value1,key2=nvme5n1value2"));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n2");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n3");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, NULL);
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n4");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme5n4value1,key2=nvme5n4value2"));
-
-    int result = identify_disks();
-
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "/dev/nvme5n1: key1=nvme5n1value1,key2=nvme5n1value2\n"
-                                          "/dev/nvme5n2: \n"
-                                          "/dev/nvme5n4: key1=nvme5n4value1,key2=nvme5n4value2\n");
-}
-
-static void test_identify_disks_success_no_namespaces(void **state)
-{
-    (void)state; // Unused parameter
-
-    create_file(fake_sys_class_nvme_path, "nvme0/device/vendor", "0x1414");
-
-    int result = identify_disks();
-
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "");
-}
-
-static void test_identify_disks_success_one_namespace(void **state)
-{
-    (void)state; // Unused parameter
-
-    create_file(fake_sys_class_nvme_path, "nvme1/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme1/nvme1n1");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme1n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme1n1value1,key2=nvme1n1value2"));
-
-    int result = identify_disks();
-
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "/dev/nvme1n1: key1=nvme1n1value1,key2=nvme1n1value2\n");
-}
-
-static void test_identify_disks_success_two_namespaces(void **state)
-{
-    (void)state; // Unused parameter
-
-    create_file(fake_sys_class_nvme_path, "nvme2/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n1");
-    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n2");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme2n1value1,key2=nvme2n1value2"));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n2");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme2n2value1,key2=nvme2n2value2"));
-
-    int result = identify_disks();
-
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "/dev/nvme2n1: key1=nvme2n1value1,key2=nvme2n1value2\n"
-                                          "/dev/nvme2n2: key1=nvme2n2value1,key2=nvme2n2value2\n");
-}
-
-static void test_identify_disks_success_non_microsoft_controller(void **state)
-{
-    (void)state; // Unused parameter
-
-    create_file(fake_sys_class_nvme_path, "nvme4/device/vendor", "0x0000");
-    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n1");
-    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n2");
-
-    int result = identify_disks();
-
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), "");
+        int result = identify_disks();
+        assert_int_equal(result, 0);
+        assert_string_equal(capture_stderr(), test_cases[i].expected_stderr);
+        assert_string_equal(capture_stdout(), test_cases[i].expected_stdout);
+    }
 }
 
 static void test_identify_disks_combined(void **state)
 {
     (void)state; // Unused parameter
 
-    // nvme0: microsoft disk, no namespaces
-    create_file(fake_sys_class_nvme_path, "nvme0/device/vendor", "0x1414");
-
-    // nvme1: microsoft disk, one namespace
-    create_file(fake_sys_class_nvme_path, "nvme1/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme1/nvme1n1");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme1n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme1n1value1,key2=nvme1n1value2"));
-
-    // nvme2: microsoft disk, two namespaces
-    create_file(fake_sys_class_nvme_path, "nvme2/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n1");
-    create_dir(fake_sys_class_nvme_path, "nvme2/nvme2n2");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme2n1value1,key2=nvme2n1value2"));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme2n2");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme2n2value1,key2=nvme2n2value2"));
-
-    // nvme4: non-microsoft disk
-    create_file(fake_sys_class_nvme_path, "nvme4/device/vendor", "0x0000");
-    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n1");
-    create_dir(fake_sys_class_nvme_path, "nvme4/nvme4n2");
-
-    // nvme5: microsoft disk, empty vs for nsid=2, error on nsid=3 (should be
-    // skipped)
-    create_file(fake_sys_class_nvme_path, "nvme5/device/vendor", "0x1414");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n1");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n2");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n3");
-    create_dir(fake_sys_class_nvme_path, "nvme5/nvme5n4");
-
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme5n1value1,key2=nvme5n1value2"));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n2");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup(""));
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n3");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, NULL);
-    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme5n4");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme5n4value1,key2=nvme5n4value2"));
+    _setup_nvme0_microsoft_no_name_namespaces();
+    _setup_nvme1_microsoft_one_namespace();
+    _setup_nvme10_direct_disk_v2_missing_vs();
+    _setup_nvme2_microsoft_two_namespaces();
+    _setup_nvme4_non_microsoft();
+    _setup_nvme5_microsoft_mixed_namespaces();
+    _setup_nvme6_remote_accelerator_v1_with_vs();
+    _setup_nvme7_remote_accelerator_v1_without_vs();
+    _setup_nvme8_direct_disk_v1_without_vs();
+    _setup_nvme9_direct_disk_v2();
 
     int result = identify_disks();
 
     assert_int_equal(result, 0);
     assert_string_equal(capture_stderr(), "");
     assert_string_equal(capture_stdout(), "/dev/nvme1n1: key1=nvme1n1value1,key2=nvme1n1value2\n"
+                                          "/dev/nvme10n1: type=local\n"
                                           "/dev/nvme2n1: key1=nvme2n1value1,key2=nvme2n1value2\n"
                                           "/dev/nvme2n2: key1=nvme2n2value1,key2=nvme2n2value2\n"
                                           "/dev/nvme5n1: key1=nvme5n1value1,key2=nvme5n1value2\n"
                                           "/dev/nvme5n2: \n"
-                                          "/dev/nvme5n4: key1=nvme5n4value1,key2=nvme5n4value2\n");
+                                          "/dev/nvme5n4: key1=nvme5n4value1,key2=nvme5n4value2\n"
+                                          "/dev/nvme6n1: key1=nvme6n1value1,key2=nvme6n1value2\n"
+                                          "/dev/nvme7n1: type=os\n"
+                                          "/dev/nvme7n2: type=data,lun=0\n"
+                                          "/dev/nvme7n3: type=data,lun=1\n"
+                                          "/dev/nvme7n4: type=data,lun=2\n"
+                                          "/dev/nvme7n9: type=data,lun=7\n"
+                                          "/dev/nvme8n1: type=local\n"
+                                          "/dev/nvme9n1: key1=nvme9n1value1,key2=nvme9n1value2\n");
 }
 
 int main(void)
 {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_trim_trailing_whitespace),
         cmocka_unit_test_setup_teardown(test_identify_disks_no_sys_class_nvme_present, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_no_nvme_devices, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_vs_error, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_success_no_namespaces, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_success_one_namespace, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_success_two_namespaces, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_success_non_microsoft_controller, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_identify_disks, setup, teardown),
         cmocka_unit_test_setup_teardown(test_identify_disks_combined, setup, teardown),
     };
 


### PR DESCRIPTION
Identify what we can about MSFT NVMe Accelerator v1.0 and
Microsoft NVMe Direct Disk v1 disks.

For MSFT NVMe Accelerator v1.0, identify the type and lun (if
applicable) in the same manner as udev rules do.

- Note that this does not change the udev rules. azure-nvme-id will not
  be invoked for this controller as there is no benefit to the cost of
  performing IDENTIFY_NAMESPACE on these namespaces at this time.  This
  may change in the future.

For Microsoft NVMe Direct Disk, specify type=local.  We have no
mechanism to provide a predictable name or index similar to
what is provided in v2's vendor-specific identification.

Fix some missing f-strings in selftest (non-functional assert outputs).

Refactor unit tests to make the various identify_disk test cases easier
to extend and re-use with _combined() test case.