### PR TITLE
fix(dracut): use /bin/bash in module-setup.sh

### DIFF
--- a/initramfs/dracut/modules.d/97azure-disk/module-setup.sh
+++ b/initramfs/dracut/modules.d/97azure-disk/module-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # called by dracut
 check() {
     return 0


### PR DESCRIPTION
Not every distro supports /usr/bin/bash.

Fixes https://github.com/Azure/azure-vm-utils/issues/49