### PR TITLE
feat(azure-nvme-id): add support for --format json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup
       run: |
         sudo apt update
-        sudo apt install gcc pandoc cmake -y
+        sudo apt install gcc pandoc cmake libjson-c-dev -y
     - name: Build & install project with cmake with tests disabled
       run: |
         cmake -B build -S . -DENABLE_TESTS=0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,16 @@ include(cmake/python.cmake)
 include(CTest)
 enable_testing()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(JSON_C REQUIRED json-c)
+include_directories(
+    ${CMAKE_SOURCE_DIR}/src
+    ${JSON_C_INCLUDE_DIRS}
+)
+
 add_compile_options(-Wextra -Wall $<$<CONFIG:Debug>:-Werror> -std=gnu11 -D_GNU_SOURCE=1)
 add_executable(azure-nvme-id src/debug.c src/identify_disks.c src/identify_udev.c src/main.c src/nvme.c)
+target_link_libraries(azure-nvme-id ${JSON_C_LIBRARIES})
 
 set(AZURE_NVME_ID_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/sbin" CACHE PATH "azure-nvme-id installation directory")
 set(DRACUT_MODULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/dracut/modules.d/97azure-disk" CACHE PATH "dracut modules installation directory")

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -14,7 +14,7 @@ function(add_test_executable test_name)
 
     target_include_directories(${test_name} PRIVATE ${CMOCKA_INCLUDE_DIRS} src tests)
     target_link_directories(${test_name} PRIVATE ${CMOCKA_LIBRARY_DIRS})
-    target_link_libraries(${test_name} PRIVATE ${CMOCKA_LIBRARIES} dl)
+    target_link_libraries(${test_name} PRIVATE ${JSON_C_LIBRARIES} ${CMOCKA_LIBRARIES} dl)
 
     if(TEST_WRAPPED_FUNCTIONS)
         foreach(func ${TEST_WRAPPED_FUNCTIONS})

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,7 @@ Source: azure-vm-utils
 Section: utils
 Priority: optional
 Maintainer: Chris Patterson <cpatterson@microsoft.com>
-Build-Depends: cmake, pandoc, debhelper-compat (= 12), libcmocka-dev
+Build-Depends: cmake, pandoc, debhelper-compat (= 12), libcmocka-dev, libjson-c-dev
 Standards-Version: 4.5.0
 Homepage: https://github.com/Azure/azure-vm-utils
 Rules-Requires-Root: no

--- a/packaging/fedora/azure-vm-utils.spec
+++ b/packaging/fedora/azure-vm-utils.spec
@@ -9,6 +9,7 @@ Source0:        %{name}_dev.tgz
 
 BuildRequires:  cmake
 BuildRequires:  gcc
+BuildRequires:  json-c-devel
 BuildRequires:  libcmocka-devel
 
 %description

--- a/packaging/mariner/azure-vm-utils.spec
+++ b/packaging/mariner/azure-vm-utils.spec
@@ -11,6 +11,7 @@ BuildRequires:  binutils
 BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  glibc-devel
+BuildRequires:  json-c-devel
 BuildRequires:  kernel-headers
 BuildRequires:  libcmocka-devel
 BuildRequires:  make

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -4,7 +4,18 @@ set -eux -o pipefail
 
 # Ensure dependencies are installed and up-to-date.
 sudo apt update
-sudo apt install gcc pandoc cmake devscripts debhelper libcmocka-dev build-essential clang-format cppcheck pkg-config -y
+sudo apt install -y \
+        build-essential \
+        clang-format \
+        cmake \
+        cppcheck \
+        devscripts \
+        debhelper \
+        gcc \
+        libcmocka-dev \
+        libjson-c-dev \
+        pandoc \
+        pkg-config
 
 project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 git_version="$(git describe --tags --always --dirty)"

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -24,6 +24,7 @@ logger = logging.getLogger("selftest")
 
 # pylint: disable=line-too-long
 # pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-lines
 # pylint: disable=too-many-locals
 
 

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -589,7 +589,7 @@ class AzureNvmeIdInfo:
         logger.info("validate_azure_nvme_id_help OK: {self.azure_nvme_id_help_stdout}")
 
     def validate_azure_nvme_id_json(self, disk_info: DiskInfo) -> None:
-        """Validate azure-nvme-id --output json outputs."""
+        """Validate azure-nvme-id --format json outputs."""
         assert self.azure_nvme_id_json_returncode == 0, "azure-nvme-id failed"
         if not os.path.exists("/sys/class/nvme"):
             assert (
@@ -611,7 +611,7 @@ class AzureNvmeIdInfo:
                 "Microsoft NVMe Direct Disk v2",
             )
             for disk in self.azure_nvme_id_json_disks.values()
-        ), "missing model in azure-nvme-id --output json"
+        ), "missing model in azure-nvme-id --format json"
         logger.info(
             "validate_azure_nvmve_id_json OK: %r", self.azure_nvme_id_json_stdout
         )
@@ -669,7 +669,7 @@ class AzureNvmeIdInfo:
         azure_nvme_id_disks = cls.parse_azure_nvme_id_output(azure_nvme_id_stdout)
 
         proc = subprocess.run(
-            ["azure-nvme-id", "--output", "json"], capture_output=True, check=False
+            ["azure-nvme-id", "--format", "json"], capture_output=True, check=False
         )
         azure_nvme_id_json_stdout = proc.stdout.decode("utf-8")
         azure_nvme_id_json_stderr = proc.stderr.decode("utf-8")
@@ -735,7 +735,7 @@ class AzureNvmeIdInfo:
                 "model": "MSFT NVMe Accelerator v1.0",
                 "properties": {
                     "type": "data",
-                    "lun": "31"
+                    "lun": 31
                 },
                 "vs": ""
             },
@@ -744,7 +744,7 @@ class AzureNvmeIdInfo:
                 "model": "Microsoft NVMe Direct Disk v2",
                 "properties": {
                     "type": "local",
-                    "index": "1",
+                    "index": 1,
                     "name": "nvme-440G-1"
                 },
                 "vs": "type=local,index=1,name=nvme-440G-1"

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -611,7 +611,9 @@ class AzureNvmeIdInfo:
             )
             for disk in self.azure_nvme_id_json_disks.values()
         ), "missing model in azure-nvme-id --output json"
-        logger.info("validate_azure_nvmve_id_json OK: %r", self.azure_nvme_id_json_stdout)
+        logger.info(
+            "validate_azure_nvmve_id_json OK: %r", self.azure_nvme_id_json_stdout
+        )
 
     def validate_azure_nvme_id_version(self) -> None:
         """Validate azure-nvme-id --version outputs."""

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -9,6 +9,7 @@
 
 import argparse
 import glob
+import json
 import logging
 import os
 import re
@@ -465,10 +466,11 @@ class AzureNvmeIdDevice:
     """Azure NVMe ID device."""
 
     device: str
+    model: Optional[str]
     nvme_id: str
     type: Optional[str]
     index: Optional[int]
-    lun: Optional[str]
+    lun: Optional[int]
     name: Optional[str]
     extra: Dict[str, str]
 
@@ -480,6 +482,12 @@ class AzureNvmeIdInfo:
     azure_nvme_id_stdout: str
     azure_nvme_id_stderr: str
     azure_nvme_id_returncode: int
+    azure_nvme_id_disks: Dict[str, AzureNvmeIdDevice]
+
+    azure_nvme_id_json_stdout: str
+    azure_nvme_id_json_stderr: str
+    azure_nvme_id_json_returncode: int
+    azure_nvme_id_json_disks: Dict[str, AzureNvmeIdDevice]
 
     azure_nvme_id_help_stdout: str
     azure_nvme_id_help_stderr: str
@@ -494,7 +502,61 @@ class AzureNvmeIdInfo:
     azure_nvme_id_zzz_stderr: str
     azure_nvme_id_zzz_returncode: int
 
-    azure_nvme_id_disks: Dict[str, AzureNvmeIdDevice]
+    def _validate_azure_nvme_disks(
+        self, azure_nvme_id_disks: Dict[str, AzureNvmeIdDevice], disk_info: DiskInfo
+    ) -> None:
+        disk_cfg: Optional[AzureNvmeIdDevice] = None
+        for device_name, disk_cfg in azure_nvme_id_disks.items():
+            assert f"/dev/{device_name}" == disk_cfg.device
+            assert disk_cfg.device.startswith(
+                "/dev/nvme"
+            ), f"unexpected device: {disk_cfg}"
+
+        for device_name in disk_info.nvme_local_disks_v2:
+            assert (
+                device_name in azure_nvme_id_disks
+            ), f"missing azure-nvme-id for {device_name}"
+            disk_cfg = azure_nvme_id_disks.get(device_name)
+            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
+            assert disk_cfg.type == "local", f"unexpected local disk type {disk_cfg}"
+            assert disk_cfg.name, f"unexpected local disk name {disk_cfg}"
+            assert disk_cfg.index, f"unexpected local disk index {disk_cfg}"
+            assert disk_cfg.lun is None, f"unexpected local disk lun {disk_cfg}"
+            assert disk_cfg.nvme_id, f"unexpected local disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected local disk extra {disk_cfg}"
+
+        for device_name in disk_info.nvme_local_disks_v1:
+            assert (
+                device_name in azure_nvme_id_disks
+            ), f"missing azure-nvme-id for {device_name}"
+            disk_cfg = azure_nvme_id_disks.get(device_name)
+            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
+            assert disk_cfg.type == "local", f"unexpected disk type {disk_cfg}"
+            assert not disk_cfg.name, f"unexpected disk name {disk_cfg}"
+            assert not disk_cfg.index, f"unexpected disk index {disk_cfg}"
+            assert disk_cfg.lun is None, f"unexpected local disk lun {disk_cfg}"
+            assert disk_cfg.nvme_id, f"unexpected disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected disk extra {disk_cfg}"
+
+        for device_name in disk_info.nvme_remote_disks:
+            assert (
+                device_name in azure_nvme_id_disks
+            ), f"missing azure-nvme-id for {device_name}"
+            disk_cfg = azure_nvme_id_disks.get(device_name)
+            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
+            assert disk_cfg.type in (
+                "os",
+                "data",
+            ), f"unexpected remote disk type {disk_cfg}"
+            if disk_cfg.type == "data":
+                assert (
+                    disk_cfg.lun is not None and disk_cfg.lun >= 0
+                ), f"unexpected remote disk index {disk_cfg}"
+            else:
+                assert disk_cfg.lun is None, f"unexpected remote disk index {disk_cfg}"
+            assert not disk_cfg.name, f"unexpected remote disk name {disk_cfg}"
+            assert disk_cfg.nvme_id, f"unexpected remote disk id {disk_cfg}"
+            assert not disk_cfg.extra, f"unexpected remote disk extra {disk_cfg}"
 
     def validate_azure_nvme_id(self, disk_info: DiskInfo) -> None:
         """Validate azure-nvme-id outputs."""
@@ -509,56 +571,8 @@ class AzureNvmeIdInfo:
                 self.azure_nvme_id_stderr == ""
             ), f"unexpected azure-nvme-id stderr: {self.azure_nvme_id_stderr}"
 
-        disk_cfg: Optional[AzureNvmeIdDevice] = None
-        for device_name, disk_cfg in self.azure_nvme_id_disks.items():
-            assert f"/dev/{device_name}" == disk_cfg.device
-            assert disk_cfg.device.startswith(
-                "/dev/nvme"
-            ), f"unexpected device: {disk_cfg}"
-
-        for device_name in disk_info.nvme_local_disks_v2:
-            assert (
-                device_name in self.azure_nvme_id_disks
-            ), f"missing azure-nvme-id for {device_name}"
-            disk_cfg = self.azure_nvme_id_disks.get(device_name)
-            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
-            assert disk_cfg.type == "local", f"unexpected local disk type {disk_cfg}"
-            assert disk_cfg.name, f"unexpected local disk name {disk_cfg}"
-            assert disk_cfg.index, f"unexpected local disk index {disk_cfg}"
-            assert disk_cfg.nvme_id, f"unexpected local disk id {disk_cfg}"
-            assert not disk_cfg.extra, f"unexpected local disk extra {disk_cfg}"
-
-        for device_name in disk_info.nvme_local_disks_v1:
-            assert (
-                device_name in self.azure_nvme_id_disks
-            ), f"missing azure-nvme-id for {device_name}"
-            disk_cfg = self.azure_nvme_id_disks.get(device_name)
-            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
-            assert disk_cfg.type == "local", f"unexpected disk type {disk_cfg}"
-            assert not disk_cfg.name, f"unexpected disk name {disk_cfg}"
-            assert not disk_cfg.index, f"unexpected disk index {disk_cfg}"
-            assert disk_cfg.nvme_id, f"unexpected disk id {disk_cfg}"
-            assert not disk_cfg.extra, f"unexpected disk extra {disk_cfg}"
-
-        for device_name in disk_info.nvme_remote_disks:
-            assert (
-                device_name in self.azure_nvme_id_disks
-            ), f"missing azure-nvme-id for {device_name}"
-            disk_cfg = self.azure_nvme_id_disks.get(device_name)
-            assert disk_cfg, f"failed to find azure-nvme-id for {device_name}"
-            assert disk_cfg.type in (
-                "os",
-                "data",
-            ), f"unexpected remote disk type {disk_cfg}"
-            if disk_cfg.type == "data":
-                assert disk_cfg.lun, f"unexpected remote disk index {disk_cfg}"
-            else:
-                assert not disk_cfg.lun, f"unexpected remote disk index {disk_cfg}"
-            assert not disk_cfg.name, f"unexpected remote disk name {disk_cfg}"
-            assert disk_cfg.nvme_id, f"unexpected remote disk id {disk_cfg}"
-            assert not disk_cfg.extra, f"unexpected remote disk extra {disk_cfg}"
-
-        logger.info("validate_azure_nvmve_id: OK")
+        self._validate_azure_nvme_disks(self.azure_nvme_id_disks, disk_info)
+        logger.info("validate_azure_nvmve_id OK: %r", self.azure_nvme_id_stdout)
 
     def validate_azure_nvme_id_help(self) -> None:
         """Validate azure-nvme-id --help outputs."""
@@ -572,6 +586,32 @@ class AzureNvmeIdInfo:
         ), "unexpected azure-nvme-id --help stdout: {self.azure_nvme_id_help_stdout}"
 
         logger.info("validate_azure_nvme_id_help OK: {self.azure_nvme_id_help_stdout}")
+
+    def validate_azure_nvme_id_json(self, disk_info: DiskInfo) -> None:
+        """Validate azure-nvme-id --output json outputs."""
+        assert self.azure_nvme_id_json_returncode == 0, "azure-nvme-id failed"
+        if not os.path.exists("/sys/class/nvme"):
+            assert (
+                self.azure_nvme_id_json_stderr
+                == "no NVMe devices in /sys/class/nvme: No such file or directory\n"
+            ), f"unexpected azure-nvme-id stderr without /sys/class/nvme: {self.azure_nvme_id_json_stderr}"
+        else:
+            assert (
+                self.azure_nvme_id_json_stderr == ""
+            ), f"unexpected azure-nvme-id stderr: {self.azure_nvme_id_json_stderr}"
+
+        self._validate_azure_nvme_disks(self.azure_nvme_id_disks, disk_info)
+
+        assert all(
+            disk.model
+            in (
+                "MSFT NVMe Accelerator v1.0",
+                "Microsoft NVMe Direct Disk",
+                "Microsoft NVMe Direct Disk v2",
+            )
+            for disk in self.azure_nvme_id_json_disks.values()
+        ), "missing model in azure-nvme-id --output json"
+        logger.info("validate_azure_nvmve_id_json OK: %r", self.azure_nvme_id_json_stdout)
 
     def validate_azure_nvme_id_version(self) -> None:
         """Validate azure-nvme-id --version outputs."""
@@ -614,6 +654,7 @@ class AzureNvmeIdInfo:
         self.validate_azure_nvme_id_version()
         self.validate_azure_nvme_id_zzz_invalid_arg()
         self.validate_azure_nvme_id(disk_info)
+        self.validate_azure_nvme_id_json(disk_info)
 
     @classmethod
     def gather(cls) -> "AzureNvmeIdInfo":
@@ -622,6 +663,17 @@ class AzureNvmeIdInfo:
         azure_nvme_id_stdout = proc.stdout.decode("utf-8")
         azure_nvme_id_stderr = proc.stderr.decode("utf-8")
         azure_nvme_id_returncode = proc.returncode
+        azure_nvme_id_disks = cls.parse_azure_nvme_id_output(azure_nvme_id_stdout)
+
+        proc = subprocess.run(
+            ["azure-nvme-id", "--output", "json"], capture_output=True, check=False
+        )
+        azure_nvme_id_json_stdout = proc.stdout.decode("utf-8")
+        azure_nvme_id_json_stderr = proc.stderr.decode("utf-8")
+        azure_nvme_id_json_returncode = proc.returncode
+        azure_nvme_id_json_disks = cls.parse_azure_nvme_id_json_output(
+            azure_nvme_id_json_stdout
+        )
 
         proc = subprocess.run(
             ["azure-nvme-id", "--help"], capture_output=True, check=False
@@ -639,7 +691,6 @@ class AzureNvmeIdInfo:
         azure_nvme_id_version = cls.parse_azure_nvme_id_version(
             azure_nvme_id_version_stdout
         )
-        azure_nvme_id_disks = cls.parse_azure_nvme_id_output(azure_nvme_id_stdout)
 
         proc = subprocess.run(
             ["azure-nvme-id", "zzz"], capture_output=True, check=False
@@ -655,17 +706,75 @@ class AzureNvmeIdInfo:
             azure_nvme_id_help_stdout=azure_nvme_id_help_stdout,
             azure_nvme_id_help_stderr=azure_nvme_id_help_stderr,
             azure_nvme_id_help_returncode=azure_nvme_id_help_returncode,
+            azure_nvme_id_disks=azure_nvme_id_disks,
+            azure_nvme_id_json_stdout=azure_nvme_id_json_stdout,
+            azure_nvme_id_json_stderr=azure_nvme_id_json_stderr,
+            azure_nvme_id_json_returncode=azure_nvme_id_json_returncode,
+            azure_nvme_id_json_disks=azure_nvme_id_json_disks,
             azure_nvme_id_version_stdout=azure_nvme_id_version_stdout,
             azure_nvme_id_version_stderr=azure_nvme_id_version_stderr,
             azure_nvme_id_version_returncode=azure_nvme_id_version_returncode,
             azure_nvme_id_version=azure_nvme_id_version,
-            azure_nvme_id_disks=azure_nvme_id_disks,
             azure_nvme_id_zzz_returncode=azure_nvme_id_zzz_returncode,
             azure_nvme_id_zzz_stdout=azure_nvme_id_zzz_stdout,
             azure_nvme_id_zzz_stderr=azure_nvme_id_zzz_stderr,
         )
         logger.info("azure-nvme-id info: %r", azure_nvme_id_info)
         return azure_nvme_id_info
+
+    @staticmethod
+    def parse_azure_nvme_id_json_output(output: str) -> Dict[str, AzureNvmeIdDevice]:
+        """Parse azure-nvme-id --format json output.
+        Example output:
+        [
+            {
+                "path": "/dev/nvme0n33",
+                "model": "MSFT NVMe Accelerator v1.0",
+                "properties": {
+                    "type": "data",
+                    "lun": "31"
+                },
+                "vs": ""
+            },
+            {
+                "path": "/dev/nvme1n1",
+                "model": "Microsoft NVMe Direct Disk v2",
+                "properties": {
+                    "type": "local",
+                    "index": "1",
+                    "name": "nvme-440G-1"
+                },
+                "vs": "type=local,index=1,name=nvme-440G-1"
+            }
+        ]
+        """
+        devices = {}
+
+        for device in json.loads(output):
+            device_path = device["path"]
+            model = device["model"]
+            properties = device["properties"]
+            device_type = properties.pop("type", None)
+            device_index = (
+                int(properties.pop("index")) if "index" in properties else None
+            )
+            device_lun = int(properties.pop("lun")) if "lun" in properties else None
+            device_name = properties.pop("name", None)
+            azure_nvme_id_device = AzureNvmeIdDevice(
+                device=device_path,
+                model=model,
+                nvme_id=",".join([f"{k}={v}" for k, v in properties.items()]),
+                type=device_type,
+                index=device_index,
+                lun=device_lun,
+                name=device_name,
+                extra=properties,
+            )
+
+            key = device_path.split("/")[-1]
+            devices[key] = azure_nvme_id_device
+
+        return devices
 
     @staticmethod
     def parse_azure_nvme_id_output(output: str) -> Dict[str, AzureNvmeIdDevice]:
@@ -700,10 +809,11 @@ class AzureNvmeIdInfo:
             device_index = (
                 int(properties.pop("index")) if "index" in properties else None
             )
-            device_lun = properties.pop("lun", None)
+            device_lun = int(properties.pop("lun")) if "lun" in properties else None
             device_name = properties.pop("name", None)
             azure_nvme_id_device = AzureNvmeIdDevice(
                 device=device,
+                model=None,
                 nvme_id=nvme_id,
                 type=device_type,
                 index=device_index,

--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -186,7 +186,7 @@ void enumerate_namespaces_for_controller(struct nvme_controller *ctrl, struct co
         }
         else
         {
-            json_object_object_add(namespace_obj, "vs", json_object_new_null());
+            json_object_object_add(namespace_obj, "vs", NULL);
         }
 
         free(namelist[i]);

--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -116,7 +116,14 @@ json_object *parse_vs_string(const char *vs)
 
         if (key != NULL && value != NULL)
         {
-            json_object_object_add(vs_obj, key, json_object_new_string(value));
+            if ((strcmp(key, "lun") == 0) || (strcmp(key, "index") == 0))
+            {
+                json_object_object_add(vs_obj, key, json_object_new_int(atoi(value)));
+            }
+            else
+            {
+                json_object_object_add(vs_obj, key, json_object_new_string(value));
+            }
         }
     }
 

--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -298,13 +298,9 @@ int identify_disks(struct context *ctx)
 
     free(namelist);
 
-    if (ctx->output_format == JSON || ctx->output_format == JSON_PRETTY)
+    if (ctx->output_format == JSON)
     {
-        int flags = JSON_C_TO_STRING_NOSLASHESCAPE;
-        if (ctx->output_format == JSON_PRETTY)
-        {
-            flags |= JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED;
-        }
+        int flags = JSON_C_TO_STRING_NOSLASHESCAPE | JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED;
 
         const char *json_output = json_object_to_json_string_ext(namespaces_array, flags);
         printf("%s\n", json_output);

--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -298,10 +298,15 @@ int identify_disks(struct context *ctx)
 
     free(namelist);
 
-    if (ctx->output_format == JSON)
+    if (ctx->output_format == JSON || ctx->output_format == JSON_PRETTY)
     {
-        const char *json_output = json_object_to_json_string_ext(
-            namespaces_array, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED | JSON_C_TO_STRING_NOSLASHESCAPE);
+        int flags = JSON_C_TO_STRING_NOSLASHESCAPE;
+        if (ctx->output_format == JSON_PRETTY)
+        {
+            flags |= JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED;
+        }
+
+        const char *json_output = json_object_to_json_string_ext(namespaces_array, flags);
         printf("%s\n", json_output);
         json_object_put(namespaces_array);
     }

--- a/src/identify_disks.c
+++ b/src/identify_disks.c
@@ -116,9 +116,18 @@ json_object *parse_vs_string(const char *vs)
 
         if (key != NULL && value != NULL)
         {
+            int int_value = atoi(value);
             if ((strcmp(key, "lun") == 0) || (strcmp(key, "index") == 0))
             {
-                json_object_object_add(vs_obj, key, json_object_new_int(atoi(value)));
+                if (int_value == 0 && strcmp(value, "0") != 0)
+                {
+                    fprintf(stderr, "failed to parse vs=%s key=%s value=%s as int\n", vs, key, value);
+                    json_object_object_add(vs_obj, key, json_object_new_string(value));
+                }
+                else
+                {
+                    json_object_object_add(vs_obj, key, json_object_new_int(int_value));
+                }
             }
             else
             {

--- a/src/identify_disks.h
+++ b/src/identify_disks.h
@@ -8,6 +8,7 @@
 #define __IDENTIFY_DISKS_H__
 
 #include <dirent.h>
+#include <json-c/json.h>
 #include <stdio.h>
 
 #define MAX_PATH 4096
@@ -28,11 +29,21 @@ struct nvme_controller
     char model[MAX_PATH];
 };
 
+struct context
+{
+    enum
+    {
+        PLAIN,
+        JSON
+    } output_format;
+};
+
 void trim_trailing_whitespace(char *str);
 int is_microsoft_nvme_device(const char *device_name);
 int is_nvme_namespace(const struct dirent *entry);
-int enumerate_namespaces_for_controller(struct nvme_controller *ctrl);
+void enumerate_namespaces_for_controller(struct nvme_controller *ctrl, struct context *ctx,
+                                         json_object *namespaces_array);
 int is_azure_nvme_controller(const struct dirent *entry);
-int identify_disks(void);
+int identify_disks(struct context *ctx);
 
 #endif // __IDENTIFY_DISKS_H__

--- a/src/identify_disks.h
+++ b/src/identify_disks.h
@@ -34,7 +34,8 @@ struct context
     enum
     {
         PLAIN,
-        JSON
+        JSON,
+        JSON_PRETTY,
     } output_format;
 };
 

--- a/src/identify_disks.h
+++ b/src/identify_disks.h
@@ -35,7 +35,6 @@ struct context
     {
         PLAIN,
         JSON,
-        JSON_PRETTY,
     } output_format;
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@ void print_help(const char *program)
     printf("  -d, --debug    Enable debug mode\n");
     printf("  -u, --udev     Enable udev mode\n");
     printf("  -h, --help     Display this help message\n");
-    printf("  -o, --output {plain|json} Output format (default=plain)\n");
+    printf("  -o, --output {plain|json|json-pretty} Output format (default=plain)\n");
     printf("  -v, --version  Display the version\n");
 }
 
@@ -65,6 +65,10 @@ int main(int argc, char **argv)
             if (strcmp(optarg, "json") == 0)
             {
                 ctx.output_format = JSON;
+            }
+            else if (strcmp(optarg, "json-pretty") == 0)
+            {
+                ctx.output_format = JSON_PRETTY;
             }
             else if (strcmp(optarg, "plain") == 0)
             {

--- a/src/main.c
+++ b/src/main.c
@@ -41,9 +41,15 @@ int main(int argc, char **argv)
     int opt;
     int option_index = 0;
 
-    static struct option long_options[] = {{"debug", no_argument, 0, 'd'},        {"udev", no_argument, 0, 'u'},
-                                           {"version", no_argument, 0, 'v'},      {"help", no_argument, 0, 'h'},
-                                           {"format", required_argument, 0, 'o'}, {0, 0, 0, 0}};
+    // clang-format off
+    static struct option long_options[] = {
+           {"debug", no_argument, 0, 'd'},
+           {"udev", no_argument, 0, 'u'},
+           {"version", no_argument, 0, 'v'},
+           {"help", no_argument, 0, 'h'},
+           {"format", required_argument, 0, 'f'},
+           {0, 0, 0, 0}};
+    // clang-format on
 
     while ((opt = getopt_long(argc, argv, "duvhf:", long_options, &option_index)) != -1)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@ void print_help(const char *program)
     printf("  -d, --debug    Enable debug mode\n");
     printf("  -u, --udev     Enable udev mode\n");
     printf("  -h, --help     Display this help message\n");
+    printf("  -o, --output {plain|json} Output format (default=plain)\n");
     printf("  -v, --version  Display the version\n");
 }
 
@@ -35,17 +36,16 @@ void print_invalid_argument(const char *program, const char *argument)
 int main(int argc, char **argv)
 {
     bool udev_mode = false;
+    struct context ctx = {.output_format = PLAIN};
 
     int opt;
     int option_index = 0;
 
-    static struct option long_options[] = {{"debug", no_argument, 0, 'd'},
-                                           {"udev", no_argument, 0, 'u'},
-                                           {"version", no_argument, 0, 'v'},
-                                           {"help", no_argument, 0, 'h'},
-                                           {0, 0, 0, 0}};
+    static struct option long_options[] = {{"debug", no_argument, 0, 'd'},        {"udev", no_argument, 0, 'u'},
+                                           {"version", no_argument, 0, 'v'},      {"help", no_argument, 0, 'h'},
+                                           {"output", required_argument, 0, 'o'}, {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "duvh", long_options, &option_index)) != -1)
+    while ((opt = getopt_long(argc, argv, "duvho:", long_options, &option_index)) != -1)
     {
         switch (opt)
         {
@@ -61,6 +61,21 @@ int main(int argc, char **argv)
         case 'h':
             print_help(argv[0]);
             return 0;
+        case 'o':
+            if (strcmp(optarg, "json") == 0)
+            {
+                ctx.output_format = JSON;
+            }
+            else if (strcmp(optarg, "plain") == 0)
+            {
+                ctx.output_format = PLAIN;
+            }
+            else
+            {
+                print_invalid_argument(argv[0], optarg);
+                return 1;
+            }
+            break;
         default:
             // Error for invalid --args
             print_invalid_argument(argv[0], argv[optind - 1]);
@@ -85,5 +100,5 @@ int main(int argc, char **argv)
         return identify_udev_device();
     }
 
-    return identify_disks();
+    return identify_disks(&ctx);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -15,11 +15,11 @@
 void print_help(const char *program)
 {
     printf("Usage: %s [-d|--debug] [-u|--udev|-h|--help|-v|--version]\n", program);
-    printf("  -d, --debug    Enable debug mode\n");
-    printf("  -u, --udev     Enable udev mode\n");
-    printf("  -h, --help     Display this help message\n");
-    printf("  -o, --output {plain|json|json-pretty} Output format (default=plain)\n");
-    printf("  -v, --version  Display the version\n");
+    printf("  -d, --debug               Enable debug mode\n");
+    printf("  -f, --format {plain|json} Output format (default=plain)\n");
+    printf("  -h, --help                Display this help message\n");
+    printf("  -u, --udev                Enable udev mode\n");
+    printf("  -v, --version             Display the version\n");
 }
 
 void print_version(const char *program)
@@ -43,9 +43,9 @@ int main(int argc, char **argv)
 
     static struct option long_options[] = {{"debug", no_argument, 0, 'd'},        {"udev", no_argument, 0, 'u'},
                                            {"version", no_argument, 0, 'v'},      {"help", no_argument, 0, 'h'},
-                                           {"output", required_argument, 0, 'o'}, {0, 0, 0, 0}};
+                                           {"format", required_argument, 0, 'o'}, {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "duvho:", long_options, &option_index)) != -1)
+    while ((opt = getopt_long(argc, argv, "duvhf:", long_options, &option_index)) != -1)
     {
         switch (opt)
         {
@@ -61,14 +61,10 @@ int main(int argc, char **argv)
         case 'h':
             print_help(argv[0]);
             return 0;
-        case 'o':
+        case 'f':
             if (strcmp(optarg, "json") == 0)
             {
                 ctx.output_format = JSON;
-            }
-            else if (strcmp(optarg, "json-pretty") == 0)
-            {
-                ctx.output_format = JSON_PRETTY;
             }
             else if (strcmp(optarg, "plain") == 0)
             {

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -449,7 +449,78 @@ static void test_identify_disks_combined_json(void **state)
     struct context ctx = {.output_format = JSON};
     int result = identify_disks(&ctx);
 
+    // clang-format off
+    const char *expected_string =
+    "[{\"path\":\"/dev/nvme1n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme1n1value1\",\"key2\":\"nvme1n1value2\"},\"vs\":\"key1=nvme1n1value1,key2=nvme1n1value2\"},"
+    "{\"path\":\"/dev/nvme2n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n1value1\",\"key2\":\"nvme2n1value2\"},\"vs\":\"key1=nvme2n1value1,key2=nvme2n1value2\"},"
+    "{\"path\":\"/dev/nvme2n2\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n2value1\",\"key2\":\"nvme2n2value2\"},\"vs\":\"key1=nvme2n2value1,key2=nvme2n2value2\"},"
+    "{\"path\":\"/dev/nvme5n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n1value1\",\"key2\":\"nvme5n1value2\"},\"vs\":\"key1=nvme5n1value1,key2=nvme5n1value2\"},"
+    "{\"path\":\"/dev/nvme5n2\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme5n3\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":null},"
+    "{\"path\":\"/dev/nvme5n4\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n4value1\",\"key2\":\"nvme5n4value2\"},\"vs\":\"key1=nvme5n4value1,key2=nvme5n4value2\"},"
+    "{\"path\":\"/dev/nvme5n32\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n32value1\"},\"vs\":\"key1=nvme5n32value1\"},"
+    "{\"path\":\"/dev/nvme5n315\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n315value1\"},\"vs\":\"key1=nvme5n315value1\"},"
+    "{\"path\":\"/dev/nvme6n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"key1\":\"nvme6n1value1\",\"key2\":\"nvme6n1value2\"},\"vs\":\"key1=nvme6n1value1,key2=nvme6n1value2\"},"
+    "{\"path\":\"/dev/nvme7n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"os\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme7n2\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"0\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme7n3\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"1\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme7n4\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"2\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme7n9\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"7\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme8n1\",\"model\":\"Microsoft NVMe Direct Disk\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"},"
+    "{\"path\":\"/dev/nvme9n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"key1\":\"nvme9n1value1\",\"key2\":\"nvme9n1value2\"},\"vs\":\"key1=nvme9n1value1,key2=nvme9n1value2\"},"
+    "{\"path\":\"/dev/nvme10n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"}]\n";
+    // clang-format on
+
     assert_int_equal(result, 0);
+    assert_string_equal(capture_stderr(), "");
+    assert_string_equal(capture_stdout(), expected_string);
+}
+
+/**
+ * json-c suffers from a pretty string spaced bug in earlier versions.access
+ * Known to impact 0.13.1 in use on RHEL-8.access
+ */
+bool check_if_jsonc_suffers_pretty_string_spaced_bug(void)
+{
+    json_object *jarray = json_object_new_array();
+    const char *json_str = json_object_to_json_string_ext(jarray, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);
+    bool result = strstr(json_str, "[\n ]") != NULL;
+    json_object_put(jarray);
+    return result;
+}
+
+void print_string_in_hex(const char *str)
+{
+    while (*str)
+    {
+        printf("%02x ", (unsigned char)*str);
+        str++;
+    }
+    printf("\n");
+}
+
+static void test_identify_disks_combined_json_pretty(void **state)
+{
+    (void)state; // Unused parameter
+
+    bool json_c_buggy = check_if_jsonc_suffers_pretty_string_spaced_bug();
+
+    _setup_nvme0_microsoft_no_name_namespaces();
+    _setup_nvme1_microsoft_one_namespace();
+    _setup_nvme2_microsoft_two_namespaces();
+    _setup_nvme4_non_microsoft();
+    _setup_nvme5_microsoft_mixed_namespaces();
+    _setup_nvme6_remote_accelerator_v1_with_vs();
+    _setup_nvme7_remote_accelerator_v1_without_vs();
+    _setup_nvme8_direct_disk_v1_without_vs();
+    _setup_nvme9_direct_disk_v2();
+    _setup_nvme10_direct_disk_v2_missing_vs();
+
+    struct context ctx = {.output_format = JSON_PRETTY};
+    int result = identify_disks(&ctx);
+
+    assert_int_equal(result, 0);
+
     assert_string_equal(capture_stderr(), "");
 
     // To help with diffing failures, we split the expected output into lines.
@@ -615,8 +686,29 @@ static void test_identify_disks_combined_json(void **state)
     int line_index = 0;
     while (line != NULL)
     {
-        printf("checking line %d: %s\n", line_index, line);
-        assert_string_equal(line, expected_lines[line_index]);
+        char *prefixed_line = NULL;
+        if (json_c_buggy && line_index > 0)
+        {
+            asprintf(&prefixed_line, " %s", expected_lines[line_index]);
+        }
+        else
+        {
+            prefixed_line = strdup(expected_lines[line_index]);
+        }
+
+        printf("checking line %d (shifted for bug=%d): %s\n", line_index, json_c_buggy, line);
+        printf("expected: ");
+        print_string_in_hex(prefixed_line);
+        printf("actual  : ");
+        print_string_in_hex(line);
+        assert_string_equal(line, prefixed_line);
+
+        if (prefixed_line)
+        {
+            free(prefixed_line);
+            prefixed_line = NULL;
+        }
+
         line = strtok(NULL, "\n");
         line_index++;
     }
@@ -632,6 +724,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_identify_disks, setup, teardown),
         cmocka_unit_test_setup_teardown(test_identify_disks_combined, setup, teardown),
         cmocka_unit_test_setup_teardown(test_identify_disks_combined_json, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_identify_disks_combined_json_pretty, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -501,31 +501,6 @@ static void test_identify_disks_combined_json(void **state)
     assert_string_equal(capture_stderr(), "");
 
     const char *json_output = capture_stdout();
-    assert_string_equal(json_output, expected_combined_json_string);
-    assert_true(compare_json_strings(json_output, expected_combined_json_string));
-}
-
-static void test_identify_disks_combined_json_pretty(void **state)
-{
-    (void)state; // Unused parameter
-
-    _setup_nvme0_microsoft_no_name_namespaces();
-    _setup_nvme1_microsoft_one_namespace();
-    _setup_nvme2_microsoft_two_namespaces();
-    _setup_nvme4_non_microsoft();
-    _setup_nvme5_microsoft_mixed_namespaces();
-    _setup_nvme6_remote_accelerator_v1_with_vs();
-    _setup_nvme7_remote_accelerator_v1_without_vs();
-    _setup_nvme8_direct_disk_v1_without_vs();
-    _setup_nvme9_direct_disk_v2();
-    _setup_nvme10_direct_disk_v2_missing_vs();
-
-    struct context ctx = {.output_format = JSON_PRETTY};
-    int result = identify_disks(&ctx);
-
-    const char *json_output = capture_stdout();
-    assert_int_equal(result, 0);
-    assert_string_equal(capture_stderr(), "");
     assert_true(compare_json_strings(json_output, expected_combined_json_string));
 
     // Pretty print in all cases will have a newline after the leading bracket.
@@ -540,7 +515,6 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_identify_disks, setup, teardown),
         cmocka_unit_test_setup_teardown(test_identify_disks_combined, setup, teardown),
         cmocka_unit_test_setup_teardown(test_identify_disks_combined_json, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_identify_disks_combined_json_pretty, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -431,6 +431,54 @@ static void test_identify_disks_combined(void **state)
                                           "/dev/nvme10n1: type=local\n");
 }
 
+// clang-format off
+static const char *expected_combined_json_string =
+"[{\"path\":\"/dev/nvme1n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme1n1value1\",\"key2\":\"nvme1n1value2\"},\"vs\":\"key1=nvme1n1value1,key2=nvme1n1value2\"},"
+"{\"path\":\"/dev/nvme2n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n1value1\",\"key2\":\"nvme2n1value2\"},\"vs\":\"key1=nvme2n1value1,key2=nvme2n1value2\"},"
+"{\"path\":\"/dev/nvme2n2\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n2value1\",\"key2\":\"nvme2n2value2\"},\"vs\":\"key1=nvme2n2value1,key2=nvme2n2value2\"},"
+"{\"path\":\"/dev/nvme5n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n1value1\",\"key2\":\"nvme5n1value2\"},\"vs\":\"key1=nvme5n1value1,key2=nvme5n1value2\"},"
+"{\"path\":\"/dev/nvme5n2\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme5n3\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":null},"
+"{\"path\":\"/dev/nvme5n4\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n4value1\",\"key2\":\"nvme5n4value2\"},\"vs\":\"key1=nvme5n4value1,key2=nvme5n4value2\"},"
+"{\"path\":\"/dev/nvme5n32\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n32value1\"},\"vs\":\"key1=nvme5n32value1\"},"
+"{\"path\":\"/dev/nvme5n315\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n315value1\"},\"vs\":\"key1=nvme5n315value1\"},"
+"{\"path\":\"/dev/nvme6n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"key1\":\"nvme6n1value1\",\"key2\":\"nvme6n1value2\"},\"vs\":\"key1=nvme6n1value1,key2=nvme6n1value2\"},"
+"{\"path\":\"/dev/nvme7n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"os\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n2\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"0\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n3\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"1\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n4\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"2\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n9\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"7\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme8n1\",\"model\":\"Microsoft NVMe Direct Disk\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme9n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"key1\":\"nvme9n1value1\",\"key2\":\"nvme9n1value2\"},\"vs\":\"key1=nvme9n1value1,key2=nvme9n1value2\"},"
+"{\"path\":\"/dev/nvme10n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"}]\n";
+// clang-format on
+
+bool compare_json_strings(const char *json_str1, const char *json_str2)
+{
+    // Parse the JSON strings into json_object structures
+    json_object *json_obj1 = json_tokener_parse(json_str1);
+    json_object *json_obj2 = json_tokener_parse(json_str2);
+
+    // Check if both JSON objects are valid
+    if (json_obj1 == NULL || json_obj2 == NULL)
+    {
+        if (json_obj1)
+            json_object_put(json_obj1);
+        if (json_obj2)
+            json_object_put(json_obj2);
+        return false;
+    }
+
+    // Compare the JSON objects
+    bool are_equal = json_object_equal(json_obj1, json_obj2);
+
+    // Free the JSON objects
+    json_object_put(json_obj1);
+    json_object_put(json_obj2);
+
+    return are_equal;
+}
+
 static void test_identify_disks_combined_json(void **state)
 {
     (void)state; // Unused parameter
@@ -449,61 +497,17 @@ static void test_identify_disks_combined_json(void **state)
     struct context ctx = {.output_format = JSON};
     int result = identify_disks(&ctx);
 
-    // clang-format off
-    const char *expected_string =
-    "[{\"path\":\"/dev/nvme1n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme1n1value1\",\"key2\":\"nvme1n1value2\"},\"vs\":\"key1=nvme1n1value1,key2=nvme1n1value2\"},"
-    "{\"path\":\"/dev/nvme2n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n1value1\",\"key2\":\"nvme2n1value2\"},\"vs\":\"key1=nvme2n1value1,key2=nvme2n1value2\"},"
-    "{\"path\":\"/dev/nvme2n2\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme2n2value1\",\"key2\":\"nvme2n2value2\"},\"vs\":\"key1=nvme2n2value1,key2=nvme2n2value2\"},"
-    "{\"path\":\"/dev/nvme5n1\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n1value1\",\"key2\":\"nvme5n1value2\"},\"vs\":\"key1=nvme5n1value1,key2=nvme5n1value2\"},"
-    "{\"path\":\"/dev/nvme5n2\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme5n3\",\"model\":\"Unknown model\",\"properties\":{},\"vs\":null},"
-    "{\"path\":\"/dev/nvme5n4\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n4value1\",\"key2\":\"nvme5n4value2\"},\"vs\":\"key1=nvme5n4value1,key2=nvme5n4value2\"},"
-    "{\"path\":\"/dev/nvme5n32\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n32value1\"},\"vs\":\"key1=nvme5n32value1\"},"
-    "{\"path\":\"/dev/nvme5n315\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n315value1\"},\"vs\":\"key1=nvme5n315value1\"},"
-    "{\"path\":\"/dev/nvme6n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"key1\":\"nvme6n1value1\",\"key2\":\"nvme6n1value2\"},\"vs\":\"key1=nvme6n1value1,key2=nvme6n1value2\"},"
-    "{\"path\":\"/dev/nvme7n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"os\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme7n2\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"0\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme7n3\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"1\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme7n4\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"2\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme7n9\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"7\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme8n1\",\"model\":\"Microsoft NVMe Direct Disk\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"},"
-    "{\"path\":\"/dev/nvme9n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"key1\":\"nvme9n1value1\",\"key2\":\"nvme9n1value2\"},\"vs\":\"key1=nvme9n1value1,key2=nvme9n1value2\"},"
-    "{\"path\":\"/dev/nvme10n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"}]\n";
-    // clang-format on
-
     assert_int_equal(result, 0);
     assert_string_equal(capture_stderr(), "");
-    assert_string_equal(capture_stdout(), expected_string);
-}
 
-/**
- * json-c suffers from a pretty string spaced bug in earlier versions.access
- * Known to impact 0.13.1 in use on RHEL-8.access
- */
-bool check_if_jsonc_suffers_pretty_string_spaced_bug(void)
-{
-    json_object *jarray = json_object_new_array();
-    const char *json_str = json_object_to_json_string_ext(jarray, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED);
-    bool result = strstr(json_str, "[\n ]") != NULL;
-    json_object_put(jarray);
-    return result;
-}
-
-void print_string_in_hex(const char *str)
-{
-    while (*str)
-    {
-        printf("%02x ", (unsigned char)*str);
-        str++;
-    }
-    printf("\n");
+    const char *json_output = capture_stdout();
+    assert_string_equal(json_output, expected_combined_json_string);
+    assert_true(compare_json_strings(json_output, expected_combined_json_string));
 }
 
 static void test_identify_disks_combined_json_pretty(void **state)
 {
     (void)state; // Unused parameter
-
-    bool json_c_buggy = check_if_jsonc_suffers_pretty_string_spaced_bug();
 
     _setup_nvme0_microsoft_no_name_namespaces();
     _setup_nvme1_microsoft_one_namespace();
@@ -519,201 +523,13 @@ static void test_identify_disks_combined_json_pretty(void **state)
     struct context ctx = {.output_format = JSON_PRETTY};
     int result = identify_disks(&ctx);
 
-    assert_int_equal(result, 0);
-
-    assert_string_equal(capture_stderr(), "");
-
-    // To help with diffing failures, we split the expected output into lines.
     const char *json_output = capture_stdout();
-    const char *expected_lines[] = {"[",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme1n1\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme1n1value1\",",
-                                    "      \"key2\": \"nvme1n1value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme1n1value1,key2=nvme1n1value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme2n1\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme2n1value1\",",
-                                    "      \"key2\": \"nvme2n1value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme2n1value1,key2=nvme2n1value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme2n2\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme2n2value1\",",
-                                    "      \"key2\": \"nvme2n2value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme2n2value1,key2=nvme2n2value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n1\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme5n1value1\",",
-                                    "      \"key2\": \"nvme5n1value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme5n1value1,key2=nvme5n1value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n2\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n3\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "    },",
-                                    "    \"vs\": null",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n4\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme5n4value1\",",
-                                    "      \"key2\": \"nvme5n4value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme5n4value1,key2=nvme5n4value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n32\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme5n32value1\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme5n32value1\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme5n315\",",
-                                    "    \"model\": \"Unknown model\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme5n315value1\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme5n315value1\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme6n1\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme6n1value1\",",
-                                    "      \"key2\": \"nvme6n1value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme6n1value1,key2=nvme6n1value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme7n1\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"os\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme7n2\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"data\",",
-                                    "      \"lun\": \"0\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme7n3\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"data\",",
-                                    "      \"lun\": \"1\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme7n4\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"data\",",
-                                    "      \"lun\": \"2\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme7n9\",",
-                                    "    \"model\": \"MSFT NVMe Accelerator v1.0\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"data\",",
-                                    "      \"lun\": \"7\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme8n1\",",
-                                    "    \"model\": \"Microsoft NVMe Direct Disk\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"local\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme9n1\",",
-                                    "    \"model\": \"Microsoft NVMe Direct Disk v2\",",
-                                    "    \"properties\": {",
-                                    "      \"key1\": \"nvme9n1value1\",",
-                                    "      \"key2\": \"nvme9n1value2\"",
-                                    "    },",
-                                    "    \"vs\": \"key1=nvme9n1value1,key2=nvme9n1value2\"",
-                                    "  },",
-                                    "  {",
-                                    "    \"path\": \"/dev/nvme10n1\",",
-                                    "    \"model\": \"Microsoft NVMe Direct Disk v2\",",
-                                    "    \"properties\": {",
-                                    "      \"type\": \"local\"",
-                                    "    },",
-                                    "    \"vs\": \"\"",
-                                    "  }",
-                                    "]"};
+    assert_int_equal(result, 0);
+    assert_string_equal(capture_stderr(), "");
+    assert_true(compare_json_strings(json_output, expected_combined_json_string));
 
-    char *output_copy = strdup(json_output);
-    char *line = strtok(output_copy, "\n");
-    int line_index = 0;
-    while (line != NULL)
-    {
-        char *prefixed_line = NULL;
-        if (json_c_buggy && line_index > 0)
-        {
-            asprintf(&prefixed_line, " %s", expected_lines[line_index]);
-        }
-        else
-        {
-            prefixed_line = strdup(expected_lines[line_index]);
-        }
-
-        printf("checking line %d (shifted for bug=%d): %s\n", line_index, json_c_buggy, line);
-        printf("expected: ");
-        print_string_in_hex(prefixed_line);
-        printf("actual  : ");
-        print_string_in_hex(line);
-        assert_string_equal(line, prefixed_line);
-
-        if (prefixed_line)
-        {
-            free(prefixed_line);
-            prefixed_line = NULL;
-        }
-
-        line = strtok(NULL, "\n");
-        line_index++;
-    }
-
-    free(output_copy);
+    // Pretty print in all cases will have a newline after the leading bracket.
+    assert_true(strncmp(json_output, "[\n", 2) == 0);
 }
 
 int main(void)

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -281,10 +281,12 @@ static void _setup_nvme9_direct_disk_v2(void)
     create_file(fake_sys_class_nvme_path, "nvme9/device/vendor", "0x1414");
     create_file(fake_sys_class_nvme_path, "nvme9/model", MICROSOFT_NVME_DIRECT_DISK_V2);
     create_dir(fake_sys_class_nvme_path, "nvme9/nvme9n1");
+    create_dir(fake_sys_class_nvme_path, "nvme9/nvme9n2");
 
     expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme9n1");
-    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device,
-                strdup("key1=nvme9n1value1,key2=nvme9n1value2"));
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup("type=local,index=0,name=nvme-500G-0"));
+    expect_string(__wrap_nvme_identify_namespace_vs_for_namespace_device, namespace_path, "/dev/nvme9n2");
+    will_return(__wrap_nvme_identify_namespace_vs_for_namespace_device, strdup("type=local,index=1,name=nvme-500G-1"));
 }
 
 /**
@@ -371,7 +373,9 @@ static void test_identify_disks(void **state)
          "/dev/nvme7n4: type=data,lun=2\n"
          "/dev/nvme7n9: type=data,lun=7\n"},
         {"nvme8", _setup_nvme8_direct_disk_v1_without_vs, "", "/dev/nvme8n1: type=local\n"},
-        {"nvme9", _setup_nvme9_direct_disk_v2, "", "/dev/nvme9n1: key1=nvme9n1value1,key2=nvme9n1value2\n"},
+        {"nvme9", _setup_nvme9_direct_disk_v2, "",
+         "/dev/nvme9n1: type=local,index=0,name=nvme-500G-0\n"
+         "/dev/nvme9n2: type=local,index=1,name=nvme-500G-1\n"},
         {"nvme10", _setup_nvme10_direct_disk_v2_missing_vs, "", "/dev/nvme10n1: type=local\n"}};
 
     for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++)
@@ -427,7 +431,8 @@ static void test_identify_disks_combined(void **state)
                                           "/dev/nvme7n4: type=data,lun=2\n"
                                           "/dev/nvme7n9: type=data,lun=7\n"
                                           "/dev/nvme8n1: type=local\n"
-                                          "/dev/nvme9n1: key1=nvme9n1value1,key2=nvme9n1value2\n"
+                                          "/dev/nvme9n1: type=local,index=0,name=nvme-500G-0\n"
+                                          "/dev/nvme9n2: type=local,index=1,name=nvme-500G-1\n"
                                           "/dev/nvme10n1: type=local\n");
 }
 
@@ -444,12 +449,13 @@ static const char *expected_combined_json_string =
 "{\"path\":\"/dev/nvme5n315\",\"model\":\"Unknown model\",\"properties\":{\"key1\":\"nvme5n315value1\"},\"vs\":\"key1=nvme5n315value1\"},"
 "{\"path\":\"/dev/nvme6n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"key1\":\"nvme6n1value1\",\"key2\":\"nvme6n1value2\"},\"vs\":\"key1=nvme6n1value1,key2=nvme6n1value2\"},"
 "{\"path\":\"/dev/nvme7n1\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"os\"},\"vs\":\"\"},"
-"{\"path\":\"/dev/nvme7n2\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"0\"},\"vs\":\"\"},"
-"{\"path\":\"/dev/nvme7n3\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"1\"},\"vs\":\"\"},"
-"{\"path\":\"/dev/nvme7n4\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"2\"},\"vs\":\"\"},"
-"{\"path\":\"/dev/nvme7n9\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":\"7\"},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n2\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":0},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n3\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":1},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n4\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":2},\"vs\":\"\"},"
+"{\"path\":\"/dev/nvme7n9\",\"model\":\"MSFT NVMe Accelerator v1.0\",\"properties\":{\"type\":\"data\",\"lun\":7},\"vs\":\"\"},"
 "{\"path\":\"/dev/nvme8n1\",\"model\":\"Microsoft NVMe Direct Disk\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"},"
-"{\"path\":\"/dev/nvme9n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"key1\":\"nvme9n1value1\",\"key2\":\"nvme9n1value2\"},\"vs\":\"key1=nvme9n1value1,key2=nvme9n1value2\"},"
+"{\"path\":\"/dev/nvme9n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\",\"index\":0,\"name\":\"nvme-500G-0\"},\"vs\":\"type=local,index=0,name=nvme-500G-0\"},"
+"{\"path\":\"/dev/nvme9n2\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\",\"index\":1,\"name\":\"nvme-500G-1\"},\"vs\":\"type=local,index=1,name=nvme-500G-1\"},"
 "{\"path\":\"/dev/nvme10n1\",\"model\":\"Microsoft NVMe Direct Disk v2\",\"properties\":{\"type\":\"local\"},\"vs\":\"\"}]\n";
 // clang-format on
 


### PR DESCRIPTION
Using json-c, add support for --output json.

Return a list of devices, including:

- `path` of device
- `model` of device, with trailing white-space trimmed
- `properties` parsed from id (or vs, if available)
- `vs` string

Example output:

```
[
  {
    "path": "/dev/nvme0n1",
    "model": "MSFT NVMe Accelerator v1.0",
    "properties": {
      "type": "os"
    },
    "vs": ""
  },
  {
    "path": "/dev/nvme0n2",
    "model": "MSFT NVMe Accelerator v1.0",
    "properties": {
      "type": "data",
      "lun": 0
    },
    "vs": ""
  },
  {
    "path": "/dev/nvme0n3",
    "model": "MSFT NVMe Accelerator v1.0",
    "properties": {
      "type": "data",
      "lun": 1
    },
    "vs": ""
  },
  {
    "path": "/dev/nvme1n1",
    "model": "Microsoft NVMe Direct Disk v2",
    "properties": {
      "type": "local",
      "index": 1,
      "name": "nvme-110G-1"
    },
    "vs": "type=local,index=1,name=nvme-110G-1"
  }
]
```

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>


Depends on #66 

Debatable options include:
 
1. --output {json,plain} vs --format {json,plain}
 
2. json-pretty option? Or just make json pretty.  I'm inclined towards the latter.
 
3. properties.lun: json integer (numeric) or string?
 
4. properties.index: json integer (numeric) or string?
 
5. raise properties.* (or subset of) to top-level object.  current properties include: type, name, lun, index - each of which can be raised right now.  However, I put them into properties section to avoid any potential conflict in the future, even if none are expected.
 
note that json-c's pretty format has at least three different variants depending on version.  Unit test was pared down to the validate the actual data and one simple check for spacing.
 