### PR TITLE
fix(nvme_tests): fix compilation warning for some 32-bit environments

### DIFF
--- a/tests/nvme_tests.c
+++ b/tests/nvme_tests.c
@@ -87,8 +87,8 @@ int __wrap_ioctl(int fd, unsigned long request, ...)
     struct nvme_id_ns *ns = mock_type(struct nvme_id_ns *);
     if (ns != NULL)
     {
-        memcpy((void *)cmd->addr, ns, sizeof(struct nvme_id_ns));
-        ns = (struct nvme_id_ns *)cmd->addr;
+        memcpy((void *)(uintptr_t)cmd->addr, ns, sizeof(*ns));
+        ns = (struct nvme_id_ns *)(uintptr_t)cmd->addr;
     }
 
     int ret = mock_type(int);


### PR DESCRIPTION
struct nvme_id_ns's addr is defined as u64.  When casting it a pointer, first cast it as uintptr_t to avoid pointer size conversion complaints.

Warnings seen in Debian sid armhf container:

```
/root/azure-vm-utils/tests/nvme_tests.c: In function '__wrap_ioctl':
/root/azure-vm-utils/tests/nvme_tests.c:90:16: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   90 |         memcpy((void *)cmd->addr, ns, sizeof(struct nvme_id_ns));
      |                ^
/root/azure-vm-utils/tests/nvme_tests.c:91:14: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   91 |         ns = (struct nvme_id_ns *)cmd->addr;
      |              ^
```

Update to use sizeof(*ns) instead of sizeof(struct nvme_id_ns) too.