### PR TITLE
ci: add debian coverage using containers

### DIFF
--- a/.github/workflows/debs.yml
+++ b/.github/workflows/debs.yml
@@ -3,11 +3,16 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        container:
+          - ubuntu:20.04
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - debian:12
+          - debian:sid
     defaults:
       run:
         shell: bash
@@ -26,7 +31,7 @@ jobs:
         git fetch upstream --tags
     - name: Build debs
       run: |
-        DEBEMAIL="Azure VM Utils CI <azure/azure-vm-utils@github.com>" ./scripts/build-deb.sh
+        ./scripts/build-deb.sh
     - name: Lintian check
       run: |
         lintian out/*.deb

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -2,6 +2,12 @@
 # shellcheck disable=SC1091
 set -eu -o pipefail
 
+if [[ $UID -ne 0 ]]; then
+    sudo_cmd="sudo"
+else
+    sudo_cmd=""
+fi
+
 source /etc/os-release
 
 distro="$ID"
@@ -30,12 +36,7 @@ cd "${project_dir}/packaging/${distro}"
 
 # Install dependencies.
 build_requirements=$(grep ^BuildRequires azure-vm-utils.spec | awk '{{print $2}}' | tr '\n' ' ')
-install_build_requirements_cmd="dnf install -y ${build_requirements} rpm-build dracut"
-if [[ $UID -ne 0 ]]; then
-    sudo $install_build_requirements_cmd
-else
-    $install_build_requirements_cmd
-fi
+$sudo_cmd dnf install -y ${build_requirements} rpm-build dracut
 
 # Build RPM.
 rpmbuild -ba --define "__git_version ${version}" --define "__git_release ${release}" --define "_topdir ${build_dir}" azure-vm-utils.spec


### PR DESCRIPTION
.github/workflows/debs.yml:

- pivot to containers and add debian and arm environments

scripts/build-deb.sh:

- add missing deps not found in some container environments

- don't require git config or DEBEMAIL for build-deb

- only use sudo if user != root

scripts/build-rpm.sh:

- match sudo change in build-deb.sh

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>