### PR TITLE
fix(nvme_tests): support mocks for open64 and __ioctl_time64

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -40,6 +40,6 @@ add_test_executable(identify_udev_tests
 )
 
 add_test_executable(nvme_tests
-    WRAPPED_FUNCTIONS open posix_memalign ioctl close
+    WRAPPED_FUNCTIONS open open64 posix_memalign ioctl __ioctl_time64 close
     SOURCES src/nvme.c tests/nvme_tests.c
 )

--- a/tests/nvme_tests.c
+++ b/tests/nvme_tests.c
@@ -46,6 +46,14 @@ int __wrap_open(const char *pathname, int flags, ...)
     return ret;
 }
 
+/**
+ * Redirect open64 to open for platforms that use it, e.g. armhf.
+ */
+int __wrap_open64(const char *pathname, int flags, ...)
+{
+    return __wrap_open(pathname, flags);
+}
+
 int __wrap_posix_memalign(void **memptr, size_t alignment, size_t size)
 {
     check_expected(memptr);
@@ -98,6 +106,19 @@ int __wrap_ioctl(int fd, unsigned long request, ...)
     }
 
     return ret;
+}
+
+/**
+ * Redirect __ioctl_time64 to ioctl for platforms that use it, e.g. armhf.
+ */
+int __wrap___ioctl_time64(int fd, unsigned long request, ...)
+{
+    va_list args;
+    va_start(args, request);
+    void *arg = va_arg(args, void *);
+    va_end(args);
+
+    return __wrap_ioctl(fd, request, arg);
 }
 
 int __wrap_close(int fd)


### PR DESCRIPTION
Some platforms may use open64() instead of open(), and __ioctl_time64 instead of ioctl().

Add wrappers for these and redirect the wrapped functions to the correct wrapped/mock function.  Should have no effect on platforms where they aren't used.