### PR TITLE
fix(packaging): use pkg-config rather than pkgconf for deb package

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,7 @@ Source: azure-vm-utils
 Section: admin
 Priority: optional
 Maintainer: Chris Patterson <cpatterson@microsoft.com>
-Build-Depends: cmake, debhelper-compat (= 12), pkgconf, libcmocka-dev, libjson-c-dev, python3
+Build-Depends: cmake, debhelper-compat (= 12), pkg-config, libcmocka-dev, libjson-c-dev, python3
 Standards-Version: 4.5.0
 Homepage: https://github.com/Azure/azure-vm-utils
 Rules-Requires-Root: no


### PR DESCRIPTION
They are conflicting and pkg-config is newer in Ubuntu 20.04 and Ubuntu 22.04.