### PR TITLE
fix(specs/fedora): fix builds for f42/rawhide

### DIFF
--- a/.github/workflows/rpms.yml
+++ b/.github/workflows/rpms.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         container:
           - fedora:41
+          - fedora:42
+          - fedora:rawhide
           - ghcr.io/almalinux/9-base:latest
           - ghcr.io/almalinux/8-base:latest
           - mcr.microsoft.com/cbl-mariner/base/core:2.0
@@ -45,6 +47,9 @@ jobs:
             *azurelinux*|*cbl-mariner*)
               export HOME=/root # tdnf requires HOME to be set to /root
               tdnf install -y awk ca-certificates dnf --verbose
+              ;;
+            *fedora*)
+              dnf install -y awk
               ;;
           esac
           dnf install -y git sudo

--- a/packaging/fedora/azure-vm-utils.spec
+++ b/packaging/fedora/azure-vm-utils.spec
@@ -32,7 +32,7 @@ This package contains the self-test script for the Azure VM Utils package.
 %autosetup
 
 %build
-%cmake -DVERSION="%{version}-%{release}"
+%cmake -DVERSION="%{version}-%{release}" -DAZURE_NVME_ID_INSTALL_DIR="%{_bindir}"
 %cmake_build
 
 %install
@@ -51,11 +51,11 @@ This package contains the self-test script for the Azure VM Utils package.
 %{_exec_prefix}/lib/systemd/network/10-azure-unmanaged-sriov.network
 %{_exec_prefix}/lib/udev/rules.d/10-azure-unmanaged-sriov.rules
 %{_exec_prefix}/lib/udev/rules.d/80-azure-disk.rules
-%{_sbindir}/azure-nvme-id
+%{_bindir}/azure-nvme-id
 %{_mandir}/man8/azure-nvme-id.8.gz
 
 %files selftest
-%{_sbindir}/azure-vm-utils-selftest
+%{_bindir}/azure-vm-utils-selftest
 %{_mandir}/man8/azure-vm-utils-selftest.8.gz
 
 %changelog


### PR DESCRIPTION
Address sbin/bin changes by forcing install to _bindir for all
fedora builds.  This matches distro packaging for newer Fedora
builds.