### PR TITLE
test(selftest): add coverage for networking rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,32 +94,43 @@ and ssh into them to run the tests.
 To run tests against marketplace and community images with azure-vm-utils:
 
 ```
-AZURE_SUBSCRIPTION=<subscription id> \
-AZURE_LOCATION=eastus2 \
+SELFTEST_AZURE_SUBSCRIPTION=<subscription id> \
+SELFTEST_AZURE_LOCATION=eastus2 \
 pytest -v selftest
 ```
 
-To run tests for custom images and vm sizes, test_custom() is provided and can be configured via environment.
-TEST_CUSTOM_IMAGES and TEST_CUSTOM_VM_SIZES are comma-separated so multiple may be tested at a time.
+To run tests for custom images and vm sizes, the following variables are supported with comma-separated values:
+
+- SELFTEST_ARM64_IMAGES
+- SELFTEST_ARM64_VM_SIZES
+- SELFTEST_GEN1_IMAGES
+- SELFTEST_GEN1_VM_SIZES
+- SELFTEST_GEN2_IMAGES
+- SELFTEST_GEN2_VM_SIZES
 
 For example:
 
 ```
-AZURE_SUBSCRIPTION=<subscription id> \
-AZURE_LOCATION=eastus2 \
-TEST_CUSTOM_IMAGES=/my/image1,/my/image2,... \
-TEST_CUSTOM_VM_SIZES=Standard_D2ds_v5,Standard_D2ds_v6,... \
-pytest -v -k test_custom
+SELFTEST_AZURE_SUBSCRIPTION=<subscription id> \
+SELFTEST_AZURE_LOCATION=eastus2 \
+SELFTEST_GEN2_IMAGES=/my/image1,/my/image2,... \
+SELFTEST_GEN2_VM_SIZES=Standard_D2ds_v5,Standard_D2ds_v6,... \
+pytest -xvvvs -k test_gen2
 ```
 
-For convenience, the default spread of VM sizes can be re-used for custom tests by setting one of the
-following that are appropriate for the image(s) under test:
+For convenience, the default spread of VM sizes is assumed if SELFTEST_{ARM64|GEN1|GEN2}_VM_SIZES is unset.
+If unable to allocate VM, test is "skipped".
 
-```
-TEST_CUSTOM_VM_SIZES=DEFAULT_GEN1_VM_SIZES
-TEST_CUSTOM_VM_SIZES=DEFAULT_GEN2_VM_SIZES
-TEST_CUSTOM_VM_SIZES=DEFAULT_ARM64_VM_SIZES
-```
+Supported environment variables:
+
+- SELFTEST_ADMIN_USERNAME: admin name to configure VMs with
+- SELFTEST_ADMIN_PASSWORD: optional password to enable easy serial-console access
+- SELFTEST_ARTIFACTS_PATH: directory path to store artifacts under
+- SELFTEST_AZURE_LOCATION: location to use
+- SELFTEST_AZURE_SUBSCRIPTION: subscription to use
+- SELFTEST_HOLD_FAILURES: skip cleanup for failures
+- SELFTEST_REBOOTS: number of reboots to perform in test (default=50)
+- SELFTEST_RESOURCE_GROUP: optional RG to use, otherwise one is created
 
 # Contributing
 

--- a/selftest/conftest.py
+++ b/selftest/conftest.py
@@ -1,0 +1,80 @@
+# --------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for license information.
+# --------------------------------------------------------------------------
+
+"""pytest configuration for selftest."""
+
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_sessionstart(session):
+    """Initialize session attributes that are marked on finish."""
+    session.aborted = False
+    session.failed = False
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Mark test session as aborted or failed."""
+    if exitstatus == 2:  # Interrupted (e.g., Ctrl+C)
+        session.aborted = True
+    elif exitstatus != 0:
+        session.failed = True
+
+
+def pytest_configure(_config):
+    """Configure pytest logging and artifacts directory.
+
+    Create artifacts directory based on the current timestamp if not configured.
+    This is used to store logs and other artifacts generated during the test run.
+    If running under pytest-xdist, use the worker ID to create separate logs for each worker.
+    """
+    artifacts_path = os.getenv("SELFTEST_ARTIFACTS_PATH")
+    if "PYTEST_XDIST_WORKER" not in os.environ:
+        if not artifacts_path:
+            timestamp = datetime.now().strftime("%Y%m%d%H%M%S%f")
+            artifacts_path = f"/tmp/selftest-{timestamp}"
+            os.environ["SELFTEST_ARTIFACTS_PATH"] = artifacts_path
+        print(f"artifacts={artifacts_path}", file=sys.stderr)
+
+    artifacts_path = os.getenv("SELFTEST_ARTIFACTS_PATH")
+    assert artifacts_path, "SELFTEST_ARTIFACTS_PATH must be set"
+
+    log_path = Path(artifacts_path)
+    log_path.mkdir(parents=True, exist_ok=True)
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is not None:
+        logging.basicConfig(
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            filename=log_path / f"{worker_id}.log",
+            level=logging.DEBUG,
+        )
+    else:
+        logging.basicConfig(
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            filename=log_path / "main.log",
+            level=logging.DEBUG,
+        )
+        logger.debug("test")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(_config, items):
+    """Group tests by vm_size for pytest-xdist to avoid quota issues."""
+    for item in items:
+        vm_size = (
+            item.callspec.params.get("vm_size", None)
+            if hasattr(item, "callspec")
+            else None
+        )
+        if vm_size:
+            item.add_marker(pytest.mark.xdist_group(vm_size))

--- a/selftest/conftest.py
+++ b/selftest/conftest.py
@@ -16,6 +16,9 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable=unused-argument
+
+
 def pytest_sessionstart(session):
     """Initialize session attributes that are marked on finish."""
     session.aborted = False
@@ -30,7 +33,7 @@ def pytest_sessionfinish(session, exitstatus):
         session.failed = True
 
 
-def pytest_configure(_config):
+def pytest_configure(config):
     """Configure pytest logging and artifacts directory.
 
     Create artifacts directory based on the current timestamp if not configured.
@@ -68,7 +71,7 @@ def pytest_configure(_config):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(_config, items):
+def pytest_collection_modifyitems(config, items):
     """Group tests by vm_size for pytest-xdist to avoid quota issues."""
     for item in items:
         vm_size = (

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -101,9 +101,25 @@ SKU_CONFIGS = {
         nvme_controller_toggle_supported=True,
         temp_disk_size_gib=75,
     ),
-    "Standard_D2as_v6": V6SkuConfig(vm_size="Standard_D2als_v6"),
+    "Standard_D2s_v6": V6SkuConfig(vm_size="Standard_D2s_v6"),
+    "Standard_D2ds_v6": V6SkuConfig(
+        vm_size="Standard_D2ds_v6",
+        nvme_local_disk_count=1,
+        nvme_local_disk_size_gib=110,
+    ),
+    "Standard_D16ds_v6": V6SkuConfig(
+        vm_size="Standard_D16ds_v6",
+        nvme_local_disk_count=2,
+        nvme_local_disk_size_gib=440,
+    ),
+    "Standard_D32ds_v6": V6SkuConfig(
+        vm_size="Standard_D32ds_v6",
+        nvme_local_disk_count=4,
+        nvme_local_disk_size_gib=440,
+    ),
+    "Standard_D2as_v6": V6SkuConfig(vm_size="Standard_D2as_v6"),
     "Standard_D2ads_v6": V6SkuConfig(
-        vm_size="Standard_D2alds_v6",
+        vm_size="Standard_D2ads_v6",
         nvme_local_disk_count=1,
         nvme_local_disk_size_gib=110,
     ),

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -892,7 +892,7 @@ class NetworkInfo:
 
         for interface_name in interface_names:
             sys_path = Path(SYS_CLASS_NET, interface_name)
-            properties = cls.query_udev_properties(interface_name)
+            udev_properties = cls.query_udev_properties(interface_name)
             driver_path = Path(sys_path, "device", "driver")
             if not driver_path.is_symlink():
                 logger.debug(
@@ -909,7 +909,7 @@ class NetworkInfo:
                 driver=driver,
                 mac=mac,
                 ipv4_addrs=ipv4_addrs,
-                udev_properties=properties,
+                udev_properties=udev_properties,
             )
 
         return interfaces

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -970,8 +970,8 @@ class NetworkInfo:
                     key, value = line.split("=", 1)
                     properties[key] = value
             return properties
-        except subprocess.CalledProcessError as e:
-            logger.error("Failed to query udev properties for %s: %r", interface, e)
+        except subprocess.CalledProcessError as error:
+            logger.error("Failed to query udev properties for %s: %r", interface, error)
             return {}
 
     def _validate_interface(self, interface: NetworkInterface) -> None:

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -931,11 +931,11 @@ class NetworkInfo:
         return interfaces
 
     @staticmethod
-    def get_ipv4_addresses(interface: str) -> List[str]:
+    def get_ipv4_addresses(interface_name: str) -> List[str]:
         """Get the IPv4 addresses of a given network interface using `ip addr`."""
         try:
             result = subprocess.run(
-                ["ip", "-4", "addr", "show", interface],
+                ["ip", "-4", "addr", "show", interface_name],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
@@ -945,11 +945,11 @@ class NetworkInfo:
             ipv4_addresses = re.findall(r"inet (\d+\.\d+\.\d+\.\d+)", result.stdout)
             return ipv4_addresses
         except subprocess.CalledProcessError as error:
-            logger.error("failed to get IPv4 address for %s: %r", interface, error)
+            logger.error("failed to get IPv4 address for %s: %r", interface_name, error)
             raise
 
     @staticmethod
-    def query_udev_properties(interface: str) -> Dict[str, str]:
+    def query_udev_properties(interface_name: str) -> Dict[str, str]:
         """Query all udev properties for a given interface using udevadm."""
         try:
             result = subprocess.run(
@@ -957,7 +957,7 @@ class NetworkInfo:
                     "udevadm",
                     "info",
                     "--query=property",
-                    f"--path={SYS_CLASS_NET}/{interface}",
+                    f"--path={SYS_CLASS_NET}/{interface_name}",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -971,7 +971,9 @@ class NetworkInfo:
                     properties[key] = value
             return properties
         except subprocess.CalledProcessError as error:
-            logger.error("Failed to query udev properties for %s: %r", interface, error)
+            logger.error(
+                "Failed to query udev properties for %s: %r", interface_name, error
+            )
             return {}
 
     def _validate_interface(self, interface: NetworkInterface) -> None:

--- a/selftest/test_images.py
+++ b/selftest/test_images.py
@@ -7,12 +7,16 @@
 
 """Azure VM utilities self-tests script."""
 
+import codecs
+import getpass
+import logging
 import os
 import shlex
 import subprocess
 import time
+import traceback
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
 
@@ -20,116 +24,411 @@ import pytest
 
 from . import selftest
 
+logger = logging.getLogger(__name__)
+
 # pylint: disable=unknown-option-value
 # pylint: disable=line-too-long
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
 # pylint: disable=too-many-positional-arguments
 # pylint: disable=unused-argument
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=redefined-outer-name
 
-DEFAULT_GEN1_VM_SIZES = [
-    sku.vm_size
-    for sku in selftest.SKU_CONFIGS.values()
-    if sku.vm_size_type == "x64" and not sku.vm_size.endswith("v6")
+
+ARM64_IMAGES = [
+    image for image in os.getenv("SELFTEST_ARM64_IMAGES", "").split(",") if image
 ]
-
-DEFAULT_GEN2_VM_SIZES = [
-    sku.vm_size for sku in selftest.SKU_CONFIGS.values() if sku.vm_size_type == "x64"
+if not ARM64_IMAGES:
+    ARM64_IMAGES = [
+        "debian:debian-13-daily:13-arm64:latest",
+        "debian:debian-sid-daily:sid-arm64:latest",
+        "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-Arm64/versions/latest",
+    ]
+ARM64_VM_SIZES = [
+    vm_size
+    for vm_size in os.getenv("SELFTEST_ARM64_VM_SIZES", "").split(",")
+    if vm_size
 ]
+if not ARM64_VM_SIZES:
+    ARM64_VM_SIZES = [
+        sku.vm_size
+        for sku in selftest.SKU_CONFIGS.values()
+        if sku.vm_size_type == "arm64"
+    ]
 
-DEFAULT_ARM64_VM_SIZES = [
-    sku.vm_size for sku in selftest.SKU_CONFIGS.values() if sku.vm_size_type == "arm64"
+GEN1_IMAGES = [
+    image for image in os.getenv("SELFTEST_GEN1_IMAGES", "").split(",") if image
 ]
-
-CUSTOM_IMAGES = [
-    image for image in os.getenv("TEST_CUSTOM_IMAGES", "").split(",") if image
+if not GEN1_IMAGES:
+    GEN1_IMAGES = [
+        "debian:debian-13-daily:13:latest",
+        "debian:debian-sid-daily:sid:latest",
+    ]
+GEN1_VM_SIZES = [
+    vm_size for vm_size in os.getenv("SELFTEST_GEN1_VM_SIZES", "").split(",") if vm_size
 ]
-ENV_TEST_CUSTOM_VM_SIZES = os.getenv("TEST_CUSTOM_VM_SIZES", "")
-if ENV_TEST_CUSTOM_VM_SIZES == "DEFAULT_GEN1_VM_SIZES":
-    CUSTOM_VM_SIZES = DEFAULT_GEN1_VM_SIZES
-elif ENV_TEST_CUSTOM_VM_SIZES == "DEFAULT_GEN2_VM_SIZES":
-    CUSTOM_VM_SIZES = DEFAULT_GEN2_VM_SIZES
-elif ENV_TEST_CUSTOM_VM_SIZES == "DEFAULT_ARM64_VM_SIZES":
-    CUSTOM_VM_SIZES = DEFAULT_ARM64_VM_SIZES
-else:
-    CUSTOM_VM_SIZES = [image for image in ENV_TEST_CUSTOM_VM_SIZES.split(",") if image]
+if not GEN1_VM_SIZES:
+    GEN1_VM_SIZES = [
+        sku.vm_size
+        for sku in selftest.SKU_CONFIGS.values()
+        if sku.vm_size_type == "x64" and not sku.vm_size.endswith("v6")
+    ]
+
+GEN2_IMAGES = [
+    image for image in os.getenv("SELFTEST_GEN2_IMAGES", "").split(",") if image
+]
+if not GEN2_IMAGES:
+    GEN2_IMAGES = [
+        "debian:debian-13-daily:13-arm64:latest",
+        "debian:debian-sid-daily:sid-arm64:latest",
+        "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-Arm64/versions/latest",
+    ]
+GEN2_VM_SIZES = [
+    vm_size for vm_size in os.getenv("SELFTEST_GEN2_VM_SIZES", "").split(",") if vm_size
+]
+if not GEN2_VM_SIZES:
+    GEN2_VM_SIZES = [
+        sku.vm_size
+        for sku in selftest.SKU_CONFIGS.values()
+        if sku.vm_size_type == "x64"
+    ]
 
 
-def subprocess_run(cmd: List[str], check: bool = True):
+def safe_parse_bytes_literal(s: str):
+    """Parse a bytes literal string (e.g. b'foo') safely to a string (foo)."""
+    s = s.strip()
+    if not s.startswith("b'") or not s.endswith("'"):
+        return s
+
+    # Strip the b' and trailing '
+    inner = s[2:-1]
+    # Decode escape sequences (e.g., \r, \n, \x00)
+    raw_bytes: bytes = codecs.escape_decode(inner.encode())[0]  # type: ignore
+    return raw_bytes.decode("utf-8", errors="ignore").rstrip("\x00")
+
+
+def _subprocess_run(
+    cmd: List[str],
+    *,
+    artifacts_path: Path,
+    artifact_name: str,
+    check: bool = False,
+    decode: bool = False,
+) -> subprocess.CompletedProcess:
     """Run a subprocess command and capture outputs as utf-8."""
-    print(f"executing command: {shlex.join(cmd)}")
-    try:
+    artifact_path = artifacts_path / artifact_name
+    deadline = datetime.now(timezone.utc) + timedelta(minutes=30)
+    while datetime.now(timezone.utc) < deadline:
+        printable_cmd = shlex.join(cmd)
+        logger.debug("executing command: %s", printable_cmd)
         proc = subprocess.run(
             cmd,
-            check=check,
+            check=False,
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
-    except subprocess.CalledProcessError as error:
-        print(
-            f"error running command: {error} stdout={error.stdout} stderr={error.stderr}"
+        logger.debug(
+            "executed command=%s rc=%d artifact=%s",
+            printable_cmd,
+            proc.returncode,
+            artifact_path.as_posix(),
         )
-        raise
 
-    print(f"executed command: {proc}")
-    return proc
+        stdout = proc.stdout
+        stderr = proc.stderr
+        if decode:
+            # Decode potential byte repr strings from get-boot-log.
+            stdout = safe_parse_bytes_literal(stdout)
+            stderr = safe_parse_bytes_literal(stderr)
+
+        artifact_path.write_text(
+            f"cmd: {printable_cmd}\nrc: {proc.returncode}\nstdout:\n{stdout!s}\nstderr:\n{stderr!s}",
+            encoding="utf-8",
+        )
+
+        if proc.returncode != 0 and proc.stderr.startswith("ssh:"):
+            logger.debug("SSH failed, retrying...")
+            time.sleep(5)
+            continue
+
+        if check and proc.returncode != 0:
+            raise RuntimeError(
+                f"Command '{printable_cmd}' failed with return code {proc.returncode}: {artifact_path.as_posix()}"
+            )
+
+        return proc
+
+    raise RuntimeError(
+        f"Command '{shlex.join(cmd)}' timed out after 30 minutes: {artifacts_path.as_posix()}"
+    )
 
 
 @pytest.fixture
-def ssh_key_path(tmp_path):
+def artifacts_path(tmp_path, vm_size, image, temp_vm_name):
     """Generate a temporary SSH key pair for the test."""
-    path = tmp_path / "id_rsa"
-    subprocess.run(
-        ["ssh-keygen", "-t", "rsa", "-b", "2048", "-f", str(path), "-N", ""], check=True
+    artifacts_path = os.getenv("SELFTEST_ARTIFACTS_PATH")
+    if artifacts_path:
+        tmp_path = Path(artifacts_path)
+
+    path = tmp_path / vm_size / image.replace("/", "_").replace(":", "_") / temp_vm_name
+    path.mkdir(exist_ok=True, parents=True)
+    yield path
+
+
+@pytest.fixture
+def ssh_key_path(artifacts_path):
+    """Generate a temporary SSH key pair for the test."""
+    path = artifacts_path / "id_rsa"
+    _subprocess_run(
+        ["ssh-keygen", "-t", "rsa", "-b", "2048", "-f", str(path), "-N", ""],
+        artifact_name="ssh-keygen",
+        artifacts_path=artifacts_path,
+        check=True,
     )
+
     yield path
 
 
 @pytest.fixture
 def azure_subscription():
     """Get the Azure subscription ID."""
-    subscription = os.getenv("AZURE_SUBSCRIPTION_ID") or ""
-    assert subscription, "AZURE_SUBSCRIPTION_ID environment variable is required"
+    subscription = os.getenv("SELFTEST_AZURE_SUBSCRIPTION") or ""
+    assert subscription, "SELFTEST_AZURE_SUBSCRIPTION environment variable is required"
     yield subscription
 
 
 @pytest.fixture
 def azure_location():
     """Get the Azure location."""
-    location = os.getenv("AZURE_LOCATION") or ""
-    assert location, "AZURE_LOCATION environment variable is required"
+    location = os.getenv("SELFTEST_AZURE_LOCATION")
+    assert location, "SELFTEST_AZURE_LOCATION environment variable is required"
     yield location
 
 
 @pytest.fixture
-def temp_resource_group(azure_subscription, azure_location):
+def admin_username():
+    """Get the admin username."""
+    username = os.getenv("SELFTEST_ADMIN_USERNAME", "azureuser")
+    yield username
+
+
+@pytest.fixture
+def admin_password():
+    """Get the admin password."""
+    yield os.getenv("SELFTEST_ADMIN_PASSWORD")
+
+
+@pytest.fixture
+def hold_failures():
+    """Get the hold failures flag."""
+    yield bool(os.getenv("SELFTEST_HOLD_FAILURES"))
+
+
+@pytest.fixture
+def random_suffix():
+    """Generate a random suffix for the resource group."""
+    yield str(uuid.uuid4().hex[:8])
+
+
+@pytest.fixture
+def reboots():
+    """Get the number of reboots."""
+    yield int(os.getenv("SELFTEST_REBOOTS", "50"))
+
+
+@pytest.fixture
+def temp_vm_name(random_suffix):
     """Create a temporary resource group for the test."""
-    resource_group_name = f"test-rg-{uuid.uuid4()}"
-    delete_after = (datetime.utcnow() + timedelta(hours=1)).isoformat()
-    subprocess.run(
-        [
+    user = getpass.getuser()
+    yield f"temp-vm-{user}-selftest-{random_suffix}"
+
+
+def is_cleanup_permitted(request, hold_failures: bool = False) -> bool:
+    """Check to see if resources should be deleted."""
+    aborted = getattr(request.session, "aborted", False)
+    failed = getattr(request.session, "failed", False)
+
+    logger.debug(
+        "test session aborted=%s failed=%s hold_failures=%s",
+        aborted,
+        failed,
+        hold_failures,
+    )
+
+    if hold_failures and failed:
+        return False
+    return True
+
+
+@pytest.fixture
+def temp_resource_group(
+    azure_subscription,
+    azure_location,
+    delete_after_tag,
+    hold_failures,
+    random_suffix,
+    request,
+    artifacts_path,
+):
+    """Create a temporary resource group for the test."""
+    create_rg = True
+    env_rg = os.getenv("SELFTEST_RESOURCE_GROUP")
+    if env_rg:
+        resource_group_name = env_rg
+        proc = _subprocess_run(
+            [
+                "az",
+                "group",
+                "show",
+                "--subscription",
+                azure_subscription,
+                "--name",
+                resource_group_name,
+            ],
+            artifact_name="az_group_show",
+            artifacts_path=artifacts_path,
+        )
+
+        if proc.returncode == 0:
+            create_rg = False
+    else:
+        user = getpass.getuser()
+        resource_group_name = f"temp-rg-{user}-selftest-{random_suffix}"
+
+    if create_rg:
+        _subprocess_run(
+            [
+                "az",
+                "group",
+                "create",
+                "--subscription",
+                azure_subscription,
+                "--location",
+                azure_location,
+                "--name",
+                resource_group_name,
+                "--tags",
+                f"deleteAfter={delete_after_tag}",
+            ],
+            artifact_name="az_group_create",
+            artifacts_path=artifacts_path,
+            check=True,
+        )
+
+    yield resource_group_name
+
+    if not env_rg and is_cleanup_permitted(request, hold_failures):
+        _subprocess_run(
+            [
+                "az",
+                "group",
+                "delete",
+                "--name",
+                resource_group_name,
+                "--yes",
+                "--no-wait",
+            ],
+            artifact_name="az_group_delete",
+            artifacts_path=artifacts_path,
+            check=True,
+        )
+
+
+@pytest.fixture
+def public_ip(
+    temp_resource_group,
+    azure_subscription,
+    azure_location,
+    hold_failures,
+    random_suffix,
+    request,
+    artifacts_path,
+):
+    """Create a temporary public IP address for the test."""
+    while True:
+        ip_name = f"temp-ip-{random_suffix}"
+        proc = _subprocess_run(
+            [
+                "az",
+                "network",
+                "public-ip",
+                "create",
+                "--subscription",
+                azure_subscription,
+                "--resource-group",
+                temp_resource_group,
+                "--location",
+                azure_location,
+                "--name",
+                ip_name,
+                "--sku",
+                "Standard",
+                "--allocation-method",
+                "Static",
+                "--query",
+                "publicIp.ipAddress",
+                "--output",
+                "tsv",
+            ],
+            artifact_name="az_public_ip_create",
+            artifacts_path=artifacts_path,
+            check=True,
+        )
+
+        public_ip = proc.stdout.strip()
+
+        delete_cmd = [
             "az",
-            "group",
-            "create",
+            "network",
+            "public-ip",
+            "delete",
             "--subscription",
             azure_subscription,
-            "--location",
-            azure_location,
+            "--resource-group",
+            temp_resource_group,
             "--name",
-            resource_group_name,
-            "--tags",
-            f"deleteAfter={delete_after}",
-        ],
-        check=True,
-    )
-    yield resource_group_name
-    subprocess.run(
-        ["az", "group", "delete", "--name", resource_group_name, "--yes", "--no-wait"],
-        check=True,
-    )
+            ip_name,
+        ]
+
+        # Temporary workaround for VPN-unroutable networks.
+        if any(
+            public_ip.startswith(prefix) for prefix in ("20.242", "68.154.", "128.24.")
+        ):
+            _subprocess_run(
+                delete_cmd,
+                check=True,
+                artifacts_path=artifacts_path,
+                artifact_name="az_public_ip_delete",
+            )
+            continue
+
+        yield public_ip, ip_name
+
+        if is_cleanup_permitted(request, hold_failures):
+            for _ in range(30):
+                # Some retries to delete the public IP may be required.
+                proc = _subprocess_run(
+                    delete_cmd,
+                    check=False,
+                    artifacts_path=artifacts_path,
+                    artifact_name="az_public_ip_delete",
+                )
+                if proc.returncode == 0:
+                    break
+
+                time.sleep(2)
+
+        return
+
+
+@pytest.fixture
+def delete_after_tag():
+    """Get the deleteAfter tag value."""
+    yield (datetime.now(timezone.utc) + timedelta(hours=8)).isoformat()
 
 
 class TestVMs:
@@ -138,60 +437,150 @@ class TestVMs:
     @pytest.fixture(autouse=True)
     def setup(
         self,
+        admin_username,
+        admin_password,
         azure_location,
         azure_subscription,
+        artifacts_path,
+        delete_after_tag,
+        hold_failures,
+        public_ip,
+        reboots,
+        request,
         ssh_key_path,
         temp_resource_group,
+        temp_vm_name,
         image,
         vm_size,
     ):
         """Initialize the test."""
-        self.admin_username = "azureuser"
+        self.admin_username = admin_username
+        self.admin_password = admin_password
+        self.artifacts_path = artifacts_path
         self.azure_location = azure_location
         self.azure_subscription = azure_subscription
+        self.boot = 0
+        self.delete_after_tag = delete_after_tag
+        self.hold_failures = hold_failures
         self.image = image
+        self.nsg = os.getenv("SELFTEST_NSG")
+        self.public_ip, self.public_ip_name = public_ip
+        self.reboots = reboots
+        self.request = request
         self.selftest_script_path = (
             Path(os.path.abspath(__file__)).parent / "selftest.py"
         )
         self.ssh_key_path = ssh_key_path
+        self.target_script_path = f"/home/{self.admin_username}/selftest.py"
         self.temp_resource_group = temp_resource_group
-        self.vm_name = "test-vm"
+        self.vm_name = temp_vm_name
         self.vm_size = vm_size
 
-    def run_test(self) -> None:
-        """Create VM and run self-tests."""
-        target_script_path = f"/home/{self.admin_username}/selftest.py"
+        self.ssh_command = [
+            "ssh",
+            "-i",
+            self.ssh_key_path.as_posix(),
+            "-o",
+            "StrictHostKeyChecking=no",
+            f"{self.admin_username}@{self.public_ip}",
+            "--",
+            "sudo",
+        ]
+        self.vm_cfg = (
+            f"name={self.vm_name}\n"
+            f"rg={self.temp_resource_group}\n"
+            f"ip={self.public_ip}\n"
+            f"image={self.image}\n"
+            f"size={self.vm_size}\n"
+            f"ssh_key_path={self.ssh_key_path.as_posix()}\n"
+            f'ssh_cmd="{shlex.join(self.ssh_command)}"\n'
+            f'console_cmd="az serial-console connect -n {self.vm_name} -g {self.temp_resource_group}"\n'
+            f"artifacts_path={self.artifacts_path.as_posix()}\n"
+        )
+        try:
+            yield
+        finally:
+            if is_cleanup_permitted(request, hold_failures):
+                logger.info("CLEANING:\n%s", self.vm_cfg)
+                self._cleanup()
+            else:
+                logger.error(
+                    "TEST FAILED, HOLDING RESOURCES FOR DEBUGGING:\n%s",
+                    self.vm_cfg,
+                )
 
-        # Create VM with 4 data disks
-        proc = subprocess_run(
+    def _cleanup(self):
+        """Cleanup resources."""
+        proc = _subprocess_run(
             [
                 "az",
                 "vm",
-                "create",
+                "delete",
                 "--subscription",
                 self.azure_subscription,
                 "--resource-group",
                 self.temp_resource_group,
                 "--name",
                 self.vm_name,
-                "--image",
-                self.image,
-                "--size",
-                self.vm_size,
-                "--admin-username",
-                self.admin_username,
-                "--ssh-key-value",
-                f"{self.ssh_key_path}.pub",
-                "--data-disk-sizes-gb",
-                "100",
-                "200",
-                "300",
-                "400",
-                "--accept-term",
+                "--yes",
             ],
-            check=False,
+            artifacts_path=self.artifacts_path,
+            artifact_name="az_vm_delete",
         )
+        if proc.returncode != 0:
+            logger.error("failed to delete VM %s: %s", self.vm_name, proc.stderr)
 
+    def _create_vm(self) -> None:
+        """Create a VM."""
+        cmd = [
+            "az",
+            "vm",
+            "create",
+            "--subscription",
+            self.azure_subscription,
+            "--resource-group",
+            self.temp_resource_group,
+            "--location",
+            self.azure_location,
+            "--name",
+            self.vm_name,
+            "--image",
+            self.image,
+            "--size",
+            self.vm_size,
+            "--public-ip-address",
+            self.public_ip_name,
+            "--admin-username",
+            self.admin_username,
+            "--ssh-key-value",
+            f"{self.ssh_key_path}.pub",
+            "--data-disk-sizes-gb",
+            "100",
+            "200",
+            "300",
+            "400",
+            "--accept-term",
+            "--data-disk-delete-option",
+            "Delete",
+            "--nic-delete-option",
+            "Delete",
+            "--os-disk-delete-option",
+            "Delete",
+            "--tags",
+            f"deleteAfter={self.delete_after_tag}",
+        ]
+
+        if self.admin_password:
+            cmd += ["--admin-password", self.admin_password]
+
+        if self.nsg:
+            cmd += ["--nsg", self.nsg]
+
+        proc = _subprocess_run(
+            cmd,
+            artifacts_path=self.artifacts_path,
+            artifact_name="az_vm_create",
+        )
         if proc.returncode != 0:
             # Skip the test if the VM creation failed and indicate the reason.
             if "QuotaExceeded" in proc.stderr:
@@ -208,112 +597,215 @@ class TestVMs:
                 f"Unable to create VM: stdout={proc.stdout} stderr={proc.stderr}"
             )
 
-        # Get public IP address of the VM
-        public_ip_address = None
-        for _ in range(10):
-            proc = subprocess_run(
+        logger.info("CREATED VM:\n%s", self.vm_cfg)
+        (self.artifacts_path / "vm.cfg").write_text(self.vm_cfg)
+
+        # Enable boot diagnostics
+        proc = _subprocess_run(
+            [
+                "az",
+                "vm",
+                "boot-diagnostics",
+                "enable",
+                "--subscription",
+                self.azure_subscription,
+                "--resource-group",
+                self.temp_resource_group,
+                "--name",
+                self.vm_name,
+            ],
+            artifacts_path=self.artifacts_path,
+            artifact_name="az_vm_boot_diagnostics_enable",
+        )
+
+    def _execute_ssh_command(
+        self, command: List[str], *, artifact_name: str, decode: bool = False
+    ) -> subprocess.CompletedProcess:
+        """Execute a command on the VM with sudo."""
+        proc = _subprocess_run(
+            self.ssh_command + command,
+            artifacts_path=self.artifacts_path,
+            artifact_name=artifact_name,
+            decode=decode,
+        )
+        return proc
+
+    def _fetch_boot_diagnostics(self) -> None:
+        """Fetch boot diagnostics logs."""
+        for _ in range(300):
+            proc = _subprocess_run(
                 [
                     "az",
                     "vm",
-                    "list-ip-addresses",
+                    "boot-diagnostics",
+                    "get-boot-log",
                     "--subscription",
                     self.azure_subscription,
                     "--resource-group",
                     self.temp_resource_group,
                     "--name",
                     self.vm_name,
-                    "--query",
-                    "[0].virtualMachine.network.publicIpAddresses[0].ipAddress",
                     "--output",
                     "tsv",
                 ],
-                check=False,
+                artifacts_path=self.artifacts_path,
+                artifact_name=f"boot{self.boot}-console",
+                decode=True,
             )
-            public_ip_address = proc.stdout.strip()
-            if public_ip_address:
-                break
+            if proc.returncode == 0 and "BlobNotFound" not in proc.stderr:
+                return
+
             time.sleep(1)
-        else:
-            pytest.fail(
-                f"Unable to get public IP address of the VM: stdout={proc.stdout} stderr={proc.stderr}"
-            )
 
-        ssh_command = [
-            "ssh",
-            "-i",
-            self.ssh_key_path.as_posix(),
-            f"{self.admin_username}@{public_ip_address}",
-            "--",
-            "sudo",
-        ]
-
-        # Wait for the VM to be ready
-        status = "unknown"
-        while status not in ("running", "degraded"):
-            proc = subprocess_run(
-                ssh_command + ["cloud-init", "status", "--wait"], check=False
-            )
-            proc = subprocess_run(
-                ssh_command + ["systemctl", "is-system-running", "--wait"], check=False
-            )
-            status = proc.stdout.strip()
-
-        subprocess_run(
-            ssh_command + ["journalctl", "-o", "short-monotonic"], check=False
+    def _fetch_logs(self) -> None:
+        """Fetch logs."""
+        proc = self._execute_ssh_command(
+            ["journalctl", "-o", "short-monotonic", "-b"],
+            artifact_name=f"boot{self.boot}-journal",
         )
-        subprocess_run(
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"failed to fetch journalctl logs on boot {self.boot} @ {self.artifacts_path.as_posix()}: {proc.stderr}"
+            )
+
+        self._scp_from_vm("/var/log/cloud-init.log", f"boot{self.boot}-cloud-init.log")
+        self._scp_from_vm(
+            "/var/log/cloud-init-output.log", f"boot{self.boot}-cloud-init-output.log"
+        )
+        self._execute_ssh_command(
+            ["rm", "-f", "/var/log/cloud-init.log", "/var/log/cloud-init-output.log"],
+            artifact_name=f"boot{self.boot}-rm-logs",
+        )
+
+    def _run_selftest_script(self) -> None:
+        """Run selftest script on the VM."""
+        proc = self._execute_ssh_command(
+            [self.target_script_path, "--debug"],
+            artifact_name=f"boot{self.boot}-selftest",
+        )
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"self-test failed on boot {self.boot} @ {self.artifacts_path.as_posix()}: {proc.stderr}"
+            )
+
+    def _scp_from_vm(self, src: str, artifact_name: str) -> Path:
+        """Copy file from the VM using ssh with sudo."""
+        dst = self.artifacts_path / artifact_name
+        proc = self._execute_ssh_command(
+            ["cat", src], artifact_name=f"{artifact_name}.cmd"
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"failed to copy {src} -> {dst.as_posix()}: {proc.stderr}"
+            )
+
+        dst.write_text(proc.stdout, encoding="utf-8")
+        return dst
+
+    def _scp_to_vm(self, src: Path, dst: str) -> None:
+        """Copy file to VM."""
+        src_path = src.as_posix()
+        dst = f"{self.admin_username}@{self.public_ip}:{dst}"
+        proc = _subprocess_run(
             [
                 "scp",
                 "-i",
                 self.ssh_key_path.as_posix(),
-                self.selftest_script_path.as_posix(),
-                f"{self.admin_username}@{public_ip_address}:{target_script_path}",
+                src_path,
+                dst,
             ],
+            artifacts_path=self.artifacts_path,
+            artifact_name=f"scp-{src.name}",
         )
-        subprocess_run(ssh_command + [target_script_path, "--debug"], check=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"failed to scp {src_path} -> {dst}: {proc.stderr}")
+
+    def _reboot_vm(self) -> None:
+        """Reboot the VM."""
+        self._execute_ssh_command(["reboot"], artifact_name="reboot")
+        time.sleep(10)
+        self._wait_for_vm()
+
+    def _verify_image(self) -> None:
+        """Verify the image has scrubbed conflicting configurations."""
+        for config in [
+            "/etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf",
+            "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+        ]:
+            proc = self._execute_ssh_command(
+                ["test", "-f", config],
+                artifact_name=f"verify-image-{os.path.basename(config)}",
+            )
+            if proc.returncode == 0:
+                raise RuntimeError(f"config {config} found in {self.image}")
+
+    def _wait_for_vm(self) -> None:
+        """Wait for the VM to be ready."""
+        while True:
+            logger.debug("waiting for VM to be ready on boot %d...", self.boot)
+            self._execute_ssh_command(
+                ["cloud-init", "status", "--wait"], artifact_name="cloud-init-status"
+            )
+            proc = self._execute_ssh_command(
+                ["systemctl", "is-system-running", "--wait"],
+                artifact_name="systemctl-status",
+            )
+            status = proc.stdout.strip()
+            if not status:
+                status = "failed to ssh"
+
+            logger.debug("VM status: %s", status)
+            if status in ("running", "degraded"):
+                return
+
+            logger.debug("debug: %s bash", shlex.join(self.ssh_command))
+            logger.debug(
+                "       az serial-console connect --name %s --resource-group %s",
+                self.vm_name,
+                self.temp_resource_group,
+            )
+            time.sleep(2)
+
+    def run_test(self) -> None:
+        """Create VM and run self-tests."""
+        try:
+            logger.debug("artifacts path: %s", self.artifacts_path.as_posix())
+            logger.debug("public IP: %s", self.public_ip)
+            self._create_vm()
+            self._wait_for_vm()
+            self._scp_to_vm(
+                self.selftest_script_path,
+                self.target_script_path,
+            )
+            self._verify_image()
+
+            reboots = int(os.getenv("SELFTEST_REBOOTS", "50"))
+            for self.boot in range(0, reboots):
+                self._fetch_boot_diagnostics()
+                self._fetch_logs()
+                self._run_selftest_script()
+                self._reboot_vm()
+        except Exception as error:
+            self.request.session.failed = True
+            logger.error(
+                "test failed: %r\nartifacts: %s\ntraceback: %s",
+                error,
+                self.artifacts_path.as_posix(),
+                traceback.format_exc(),
+            )
+            raise RuntimeError(
+                f"test failed: {error} @ {self.artifacts_path.as_posix()}"
+            ) from error
 
     @pytest.mark.parametrize(
         "image",
-        [
-            "debian:debian-13-daily:13:latest",
-            "debian:debian-sid-daily:sid:latest",
-        ],
+        ARM64_IMAGES,
     )
     @pytest.mark.parametrize(
         "vm_size",
-        DEFAULT_GEN1_VM_SIZES,
-    )
-    def test_gen1_x64(self, image, vm_size):
-        """Test gen1 x64 images."""
-        self.run_test()
-
-    @pytest.mark.parametrize(
-        "image",
-        [
-            "debian:debian-13-daily:13-gen2:latest",
-            "debian:debian-sid-daily:sid-gen2:latest",
-            "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-x64/versions/latest",
-        ],
-    )
-    @pytest.mark.parametrize(
-        "vm_size",
-        DEFAULT_GEN2_VM_SIZES,
-    )
-    def test_gen2_x64(self, image, vm_size):
-        """Test gen2 x64 images."""
-        self.run_test()
-
-    @pytest.mark.parametrize(
-        "image",
-        [
-            "debian:debian-13-daily:13-arm64:latest",
-            "debian:debian-sid-daily:sid-arm64:latest",
-            "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-Arm64/versions/latest",
-        ],
-    )
-    @pytest.mark.parametrize(
-        "vm_size",
-        DEFAULT_ARM64_VM_SIZES,
+        ARM64_VM_SIZES,
     )
     def test_arm64(self, image, vm_size):
         """Test arm64 images."""
@@ -321,12 +813,24 @@ class TestVMs:
 
     @pytest.mark.parametrize(
         "image",
-        CUSTOM_IMAGES,
+        GEN1_IMAGES,
     )
     @pytest.mark.parametrize(
         "vm_size",
-        CUSTOM_VM_SIZES,
+        GEN1_VM_SIZES,
     )
-    def test_custom(self, image, vm_size):
-        """Test custom images."""
+    def test_gen1_x64(self, image, vm_size):
+        """Test gen1 x64 images."""
+        self.run_test()
+
+    @pytest.mark.parametrize(
+        "image",
+        GEN2_IMAGES,
+    )
+    @pytest.mark.parametrize(
+        "vm_size",
+        GEN2_VM_SIZES,
+    )
+    def test_gen2_x64(self, image, vm_size):
+        """Test gen2 x64 images."""
         self.run_test()

--- a/selftest/test_images.py
+++ b/selftest/test_images.py
@@ -120,8 +120,9 @@ def _subprocess_run(
     """Run a subprocess command and capture outputs as utf-8."""
     artifact_path = artifacts_path / artifact_name
     deadline = datetime.now(timezone.utc) + timedelta(minutes=30)
+    printable_cmd = shlex.join(cmd)
+
     while datetime.now(timezone.utc) < deadline:
-        printable_cmd = shlex.join(cmd)
         logger.debug("executing command: %s", printable_cmd)
         proc = subprocess.run(
             cmd,
@@ -163,7 +164,7 @@ def _subprocess_run(
         return proc
 
     raise RuntimeError(
-        f"Command '{shlex.join(cmd)}' timed out after 30 minutes: {artifacts_path.as_posix()}"
+        f"Command '{printable_cmd}' timed out after 30 minutes: {artifacts_path.as_posix()}"
     )
 
 

--- a/selftest/test_images.py
+++ b/selftest/test_images.py
@@ -81,9 +81,9 @@ GEN2_IMAGES = [
 ]
 if not GEN2_IMAGES:
     GEN2_IMAGES = [
-        "debian:debian-13-daily:13-arm64:latest",
-        "debian:debian-sid-daily:sid-arm64:latest",
-        "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-Arm64/versions/latest",
+        "debian:debian-13-daily:13-gen2:latest",
+        "debian:debian-sid-daily:sid-gen2:latest",
+        "/CommunityGalleries/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Images/Fedora-Cloud-Rawhide-x64/versions/latest",
     ]
 GEN2_VM_SIZES = [
     vm_size for vm_size in os.getenv("SELFTEST_GEN2_VM_SIZES", "").split(",") if vm_size

--- a/selftest/test_images.py
+++ b/selftest/test_images.py
@@ -96,7 +96,7 @@ if not GEN2_VM_SIZES:
     ]
 
 
-def safe_parse_bytes_literal(s: str):
+def safe_parse_bytes_literal(s: str) -> str:
     """Parse a bytes literal string (e.g. b'foo') safely to a string (foo)."""
     s = s.strip()
     if not s.startswith("b'") or not s.endswith("'"):


### PR DESCRIPTION
Update self-tests to:

- verify udev properties are set correctly for all interfaces
- verify unmanaged interfaces do not have an IP address assigned
- support --skip-network-validation to bypass checks if reboot is not an option
- further increase IMDS retries as it pops up on occasion. cloud-int retries IMDS for 5 minutes, so let's do that here too before failing (fairly rare event)
- include timestamps in logs

Enhance test_images:

- drop test_custom() in favor re-use of test_gen{1,2} and test_arm64 variants with their own overrides.  This makes it possible to execute all combination of tests in the same run.  They can now be overridden with `SELFTEST_{GEN1,GEN2,ARM64}_IMAGES and SELFTEST_{GEN1,GEN2,ARM64}_VM_SIZES`
- add support for reboot tests and reboot 50 times
- improve resiliency and retries for SSH
- prepend SELFTEST_ to all environment variables for configuration
- add fixtures for each environment control
- add support to hold VMs that failed test
- fetch cloud-init logs, journal logs, etc. for each reboot and save as artifacts
- check and warn if image contains legacy rules/configs.  they aren't harmful, just for awareness.

Updated environment variable controls for test_images include:

- SELFTEST_ADMIN_USERNAME: admin name to configure VMs with
- SELFTEST_ADMIN_PASSWORD: optional password to enable easy serial-console access
- SELFTEST_ARTIFACTS_PATH: directory path to store artifacts under
- SELFTEST_AZURE_LOCATION: location to use
- SELFTEST_AZURE_SUBSCRIPTION: subscription to use
- SELFTEST_HOLD_FAILURES: skip cleanup for failures, default=unset
- SELFTEST_REBOOTS: number of reboots to run tests for, default=50
- SELFTEST_RESOURCE_GROUP: optional RG to use, otherwise one is created per test VM