### PR TITLE
feat(udev): set queue/io_timeout=240s for remote Azure NVMe devices

### DIFF
--- a/.github/workflows/debs.yml
+++ b/.github/workflows/debs.yml
@@ -52,4 +52,4 @@ jobs:
         test -f /usr/share/man/man8/azure-nvme-id.8.gz
         test -f /usr/share/man/man8/azure-vm-utils-selftest.8.gz
         azure-nvme-id --version
-        azure-vm-utils-selftest --skip-imds-validation --skip-symlink-validation
+        azure-vm-utils-selftest --skip-imds-validation --skip-udev-validation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
     defaults:
       run:
         shell: bash
@@ -46,9 +46,8 @@ jobs:
         test -f /usr/local/share/man/man8/azure-nvme-id.8
         test -f /usr/local/share/man/man8/azure-vm-utils-selftest.8
         azure-nvme-id --version
-        azure-vm-utils-selftest --skip-imds-validation --skip-symlink-validation
+        azure-vm-utils-selftest --skip-imds-validation --skip-udev-validation
     - name: Verify manpages can be generated
-      if: matrix.os != 'ubuntu-20.04'
       run: |
         make -C build generate-manpages
     - name: Rebuild with tests enabled and run tests
@@ -81,9 +80,5 @@ jobs:
       run: |
         python -m venv venv
         source venv/bin/activate
-        if [ ${{ matrix.os }} == "ubuntu-20.04" ]; then
-          pip install -r selftest/test-requirements-frozen-py38.txt
-        else
-          pip install -r selftest/test-requirements-frozen.txt
-        fi
+        pip install -r selftest/test-requirements-frozen.txt
         make -C build python-lint

--- a/.github/workflows/rpms.yml
+++ b/.github/workflows/rpms.yml
@@ -86,4 +86,4 @@ jobs:
           test -f /usr/share/man/man8/azure-nvme-id.8.gz
           test -f /usr/share/man/man8/azure-vm-utils-selftest.8.gz
           azure-nvme-id --version
-          azure-vm-utils-selftest --skip-imds-validation --skip-symlink-validation
+          azure-vm-utils-selftest --skip-imds-validation --skip-udev-validation

--- a/doc/azure-vm-utils-selftest.8.in
+++ b/doc/azure-vm-utils-selftest.8.in
@@ -6,7 +6,7 @@ azure-vm-utils-selftest - packaging self-tests
 .SH SYNOPSIS
 .PP
 \f[B]azure-vm-utils-selftest [--skip-imds-validation]
-[--skip-symlink-validation]\f[R]
+[--skip-udev-validation]\f[R]
 .SH DESCRIPTION
 .PP
 \f[B]azure-vm-utils-selftest\f[R] validates functionailty related to
@@ -28,7 +28,7 @@ To run inside Azure VM without a reboot after install:
 .IP
 .nf
 \f[CR]
-azure-vm-utils-selftest --skip-symlink-validation
+azure-vm-utils-selftest --skip-udev-validation
 \f[R]
 .fi
 .PP
@@ -36,7 +36,7 @@ To run outside of Azure VM:
 .IP
 .nf
 \f[CR]
-azure-vm-utils-selftest --skip-imds-validation --skip-symlink-validation
+azure-vm-utils-selftest --skip-imds-validation --skip-udev-validation
 \f[R]
 .fi
 .PP

--- a/doc/azure-vm-utils-selftest.md
+++ b/doc/azure-vm-utils-selftest.md
@@ -31,13 +31,13 @@ $ sudo azure-vm-utils-selftest
 To run inside Azure VM without a reboot after install:
 
 ```bash
-azure-vm-utils-selftest --skip-symlink-validation
+azure-vm-utils-selftest --skip-udev-validation
 ```
 
 To run outside of Azure VM:
 
 ```bash
-azure-vm-utils-selftest --skip-imds-validation --skip-symlink-validation
+azure-vm-utils-selftest --skip-imds-validation --skip-udev-validation
 ```
 
 Hopefully it exits successfully!

--- a/selftest/selftest.py
+++ b/selftest/selftest.py
@@ -1200,8 +1200,16 @@ class AzureVmUtilsValidator:
 
     def validate_nvme_io_timeouts(self) -> None:
         """Validate NVMe queue I/O timeouts."""
-        for disk_name, timeout in self.disk_info.nvme_io_timeouts.items():
-            assert timeout == 240000, f"unexpected timeout for {disk_name}: {timeout}"
+        for namespace in self.disk_info.nvme_remote_disks:
+            assert (
+                namespace in self.disk_info.nvme_io_timeouts
+            ), f"missing NVMe I/O timeout for {namespace}"
+
+            timeout = self.disk_info.nvme_io_timeouts[namespace]
+            assert (
+                timeout == 240000
+            ), f"unexpected NVMe I/O timeout for {namespace}: {timeout} (expected 240000 ms)"
+
         logger.info("validate_nvme_io_timeouts OK: %r", self.disk_info.nvme_io_timeouts)
 
     def validate_nvme_local_disks(self) -> None:

--- a/udev/80-azure-disk.rules
+++ b/udev/80-azure-disk.rules
@@ -34,6 +34,10 @@ ATTRS{nsid}=="?*", ENV{AZURE_DISK_TYPE}="data", PROGRAM="/bin/sh -ec 'echo $$((%
 LABEL="azure_disk_nvme_id"
 ATTRS{nsid}=="?*", IMPORT{program}="/usr/sbin/azure-nvme-id --udev"
 
+LABEL="azure_disk_nvme_set_io_timeout"
+# Azure NVMe disks require 240 second I/O timeout (or greater).
+ENV{DEVTYPE}=="disk", ATTR{queue/io_timeout}="240000"
+
 LABEL="azure_disk_symlink"
 # systemd v254 ships an updated 60-persistent-storage.rules that would allow
 # these to be deduplicated using $env{.PART_SUFFIX}

--- a/udev/80-azure-disk.rules
+++ b/udev/80-azure-disk.rules
@@ -28,15 +28,16 @@ ATTRS{nsid}=="?*", ENV{AZURE_DISK_TYPE}="local", ENV{AZURE_DISK_SERIAL}="$env{ID
 GOTO="azure_disk_nvme_id"
 
 LABEL="azure_disk_nvme_remote_v1"
+# Azure hosts will retry remote I/O requests for up to 120 seconds.  If I/O times out for longer than that, host will reboot OS.
+# Set timeout for remote disks to 240 seconds, giving host time to handle the retry or reboot the VM.
+ENV{DEVTYPE}=="disk", ATTRS{nsid}=="?*", ATTR{queue/io_timeout}="240000"
+
+# For remote disks, namespace ID=1 is OS disk, ID=2+ are data disks with customer-configured lun=ID-2 (e.g. lun=0 will have nsid=2).
 ATTRS{nsid}=="1", ENV{AZURE_DISK_TYPE}="os", GOTO="azure_disk_nvme_id"
 ATTRS{nsid}=="?*", ENV{AZURE_DISK_TYPE}="data", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_DISK_LUN}="$result"
 
 LABEL="azure_disk_nvme_id"
 ATTRS{nsid}=="?*", IMPORT{program}="/usr/sbin/azure-nvme-id --udev"
-
-LABEL="azure_disk_nvme_set_io_timeout"
-# Azure NVMe disks require 240 second I/O timeout (or greater).
-ENV{DEVTYPE}=="disk", ATTR{queue/io_timeout}="240000"
 
 LABEL="azure_disk_symlink"
 # systemd v254 ships an updated 60-persistent-storage.rules that would allow


### PR DESCRIPTION
Azure hosts will retry remote I/O requests for up to 120 seconds.  If I/O times out for longer than that, the host will reboot OS.
Ensure remote disks have a timeout of 240 seconds, giving host time to handle the retry or reboot the VM.

Note that many images address this by setting nvme_core.io_timeout=240 which impacts all NVMe disks.

Self-test changes:

- Consolidate --skip-network-validation and --skip-symlink-validation into new --skip-udev-validation to avoid tests requiring udev rules being applied at boot.  This avoids adding yet another flag (in the future).

- Fix nvme_remote_disks to include os and data disks.

CI:

- Drop ubuntu-20.04 as GitHub retired it.

Fixes #80