### PR TITLE
ci(main): do a debug build to ensure -Werror is used

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         set -x
         sudo apt install -y libcmocka-dev cppcheck clang-format
         rm -rf build
-        cmake -B build -S .
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
         cd build
         make
 


### PR DESCRIPTION
This will ensure at least a pass of builds complete with -Werror.