### PR TITLE
fix(tests): include stdint.h to fix compilation errors

### DIFF
--- a/tests/capture.c
+++ b/tests/capture.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/debug_tests.c
+++ b/tests/debug_tests.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/identify_disks_tests.c
+++ b/tests/identify_disks_tests.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/identify_udev_tests.c
+++ b/tests/identify_udev_tests.c
@@ -8,6 +8,7 @@
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/nvme_tests.c
+++ b/tests/nvme_tests.c
@@ -9,6 +9,7 @@
 #include <linux/nvme_ioctl.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fedora rawhide is now failing without it, include it.