### PR TITLE
ci: Remove Fedora 41, add 43, 44, and EL 10

### DIFF
--- a/.github/workflows/rpms.yml
+++ b/.github/workflows/rpms.yml
@@ -9,9 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - fedora:41
+          # EOL May 13th, 2026
           - fedora:42
+          - fedora:43
+          - fedora:44
           - fedora:rawhide
+          - ghcr.io/almalinux/10-base:latest
           - ghcr.io/almalinux/9-base:latest
           - ghcr.io/almalinux/8-base:latest
           - mcr.microsoft.com/cbl-mariner/base/core:2.0
@@ -72,7 +75,7 @@ jobs:
       - name: Install rpms
         run: |
           dnf install -y mdadm util-linux
-          rpm -Uvh -i out/*.rpm
+          rpm -Uvh -i --nosignature out/*.rpm
       - name: Verify installation
         run: |
           set -x


### PR DESCRIPTION
Additionally, pass in the --nosignature flag when installing the RPMs; newer Fedora releases (45+) enforce signature checks by default[0].

[0] https://fedoraproject.org/wiki/Changes/Enforcing_signature_checking_by_default